### PR TITLE
Added more Vocab and Kanji filtering methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ NotifyIconWpf/bin
 UpgradeLog.htm
 packages
 .nuget
+/Kanji.DatabaseMaker/Resources/JMdict

--- a/Kanji.Common/Kanji.Common.csproj
+++ b/Kanji.Common/Kanji.Common.csproj
@@ -63,6 +63,7 @@
     <Compile Include="Models\TrayMessageEnum.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Utility\CsvFile.cs" />
+    <Compile Include="Utility\Levels.cs" />
   </ItemGroup>
   <ItemGroup />
   <ItemGroup>

--- a/Kanji.Common/Utility/Levels.cs
+++ b/Kanji.Common/Utility/Levels.cs
@@ -1,0 +1,42 @@
+﻿namespace Kanji.Common.Utility
+{
+    /// <summary>
+    /// Contains constants for the minimum and maximum JLPT and WaniKani levels.
+    /// </summary>
+    public static class Levels
+    {
+        #region Constants
+
+        /// <summary>
+        /// The minimum level of the JLPT. A lower filter value means that the item is not covered on the JLPT.
+        /// </summary>
+        public const int MinJlptLevel = 1;
+
+        /// <summary>
+        /// The maximum level of the JLPT. A higher value means that the filter is ignored.
+        /// </summary>
+        public const int MaxJlptLevel = 5;
+
+        /// <summary>
+        /// A convenience value that is equal to <see cref="MaxJlptLevel"/> + 1 and can be used when the JLPT level should be ignored.
+        /// </summary>
+        public const int IgnoreJlptLevel = MaxJlptLevel + 1;
+
+        /// <summary>
+        /// The minimum level of WaniKani. A lower value means that the filter is ignored.
+        /// </summary>
+        public const int MinWkLevel = 1;
+
+        /// <summary>
+        /// The maximum level of WaniKani. A higher value means that the item is not taught on WaniKani.
+        /// </summary>
+        public const int MaxWkLevel = 60;
+
+        /// <summary>
+        /// A convenience value that is equal to <see cref="MinWkLevel"/> - 1 and can be used when the WaniKani level should be ignored.
+        /// </summary>
+        public const int IgnoreWkLevel = MinWkLevel - 1;
+
+        #endregion
+    }
+}

--- a/Kanji.Database/Dao/VocabDao.cs
+++ b/Kanji.Database/Dao/VocabDao.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
 using System.Text;
+using Kanji.Common.Utility;
 using Kanji.Database.Entities;
 using Kanji.Database.EntityBuilders;
 using Kanji.Database.Helpers;
@@ -27,7 +28,7 @@ namespace Kanji.Database.Dao
             {
                 connection = DaoConnection.Open(DaoConnectionEnum.KanjiDatabase);
                 IEnumerable<NameValueCollection> vocabs = connection.Query(
-                      "SELECT * FROM " + SqlHelper.Table_Vocab);
+                    string.Format("SELECT * FROM {0}", SqlHelper.Table_Vocab));
 
                 foreach (NameValueCollection nvcVocab in vocabs)
                 {
@@ -60,7 +61,7 @@ namespace Kanji.Database.Dao
             {
                 connection = DaoConnection.Open(DaoConnectionEnum.KanjiDatabase);
                 IEnumerable<NameValueCollection> vocabs = connection.Query(
-                      "SELECT * FROM " + SqlHelper.Table_Vocab);
+                    string.Format("SELECT * FROM {0}", SqlHelper.Table_Vocab));
 
                 VocabBuilder builder = new VocabBuilder();
                 foreach (NameValueCollection nvcVocab in vocabs)
@@ -85,12 +86,13 @@ namespace Kanji.Database.Dao
                 //connection = DaoConnection.Open(DaoConnectionEnum.KanjiDatabase);
                 connection = _connection;
 
-                string requestString = string.Empty;
                 VocabBuilder builder = new VocabBuilder();
                 if (kanjiReading == kanaReading)
                 {
                     IEnumerable<NameValueCollection> vocabs = connection.Query(
-                      "SELECT * FROM " + SqlHelper.Table_Vocab + " WHERE " + SqlHelper.Field_Vocab_KanaWriting + "=@kanaWriting",
+                      string.Format("SELECT * FROM {0} WHERE {1}=@kanaWriting",
+                      SqlHelper.Table_Vocab,
+                      SqlHelper.Field_Vocab_KanaWriting),
                       new DaoParameter("@kanaWriting", kanaReading));
 
                     if (vocabs.Count() == 1)
@@ -101,8 +103,10 @@ namespace Kanji.Database.Dao
                 }
 
                 IEnumerable<NameValueCollection> fullMatch = connection.Query(
-                      "SELECT * FROM " + SqlHelper.Table_Vocab + " WHERE " + SqlHelper.Field_Vocab_KanaWriting + "=@kanaWriting"
-                      + " AND " + SqlHelper.Field_Vocab_KanjiWriting + "=@kanjiWriting",
+                      string.Format("SELECT * FROM {0} WHERE {1}=@kanaWriting AND {2}=@kanjiWriting",
+                      SqlHelper.Table_Vocab,
+                      SqlHelper.Field_Vocab_KanaWriting,
+                       SqlHelper.Field_Vocab_KanjiWriting),
                       new DaoParameter("@kanaWriting", kanaReading), new DaoParameter("@kanjiWriting", kanjiReading));
 
                 foreach (NameValueCollection match in fullMatch)
@@ -127,17 +131,19 @@ namespace Kanji.Database.Dao
                 //connection = DaoConnection.Open(DaoConnectionEnum.KanjiDatabase);
                 connection = _connection;
 
-                string requestString = string.Empty;
-
                 long count = (long)connection.QueryScalar(
-                    "SELECT COUNT(1) FROM " + SqlHelper.Table_Vocab + " WHERE " + SqlHelper.Field_Vocab_KanaWriting + "=@kanaWriting",
+                    string.Format("SELECT COUNT(1) FROM {0} WHERE {1}=@kanaWriting",
+                    SqlHelper.Table_Vocab,
+                    SqlHelper.Field_Vocab_KanaWriting),
                     new DaoParameter("@kanaWriting", kanaReading));
 
                 if (count == 1)
                 {
 
                     IEnumerable<NameValueCollection> vocabs = connection.Query(
-                        "SELECT * FROM " + SqlHelper.Table_Vocab + " WHERE " + SqlHelper.Field_Vocab_KanaWriting + "=@kanaWriting",
+                        string.Format("SELECT * FROM {0} WHERE {1}=@kanaWriting",
+                        SqlHelper.Table_Vocab,
+                        SqlHelper.Field_Vocab_KanaWriting),
                         new DaoParameter("@kanaWriting", kanaReading));
 
                     VocabBuilder builder = new VocabBuilder();
@@ -162,18 +168,22 @@ namespace Kanji.Database.Dao
             {
                 //connection = DaoConnection.Open(DaoConnectionEnum.KanjiDatabase);
                 connection = _connection;
-
-                string requestString = string.Empty;
-
+                
                 long count = (long)connection.QueryScalar(
-                    "SELECT COUNT(1) FROM " + SqlHelper.Table_Vocab + " WHERE " + SqlHelper.Field_Vocab_KanaWriting + "=@kanaWriting",
+                    string.Format("SELECT COUNT(1) FROM {0} WHERE {1}=@kanaWriting",
+                    SqlHelper.Table_Vocab,
+                    SqlHelper.Field_Vocab_KanaWriting),
                     new DaoParameter("@kanaWriting", kanaReading));
 
                 if (count == 1)
                 {
-                    return connection.ExecuteNonQuery("UPDATE " + SqlHelper.Table_Vocab + " SET " + SqlHelper.Field_Vocab_FrequencyRank + "="
-                        + SqlHelper.Field_Vocab_FrequencyRank + "+@rank WHERE " + SqlHelper.Field_Vocab_KanaWriting + "=@kanaWriting",
-                        new DaoParameter("@rank", rank), new DaoParameter("@kanaWriting", kanaReading)) == 1;
+                    return connection.ExecuteNonQuery(
+                        string.Format("UPDATE {0} SET {1}={1}+@rank WHERE {2}=@kanaWriting",
+                            SqlHelper.Table_Vocab,
+                            SqlHelper.Field_Vocab_FrequencyRank,
+                            SqlHelper.Field_Vocab_KanaWriting),
+                        new DaoParameter("@rank", rank),
+                        new DaoParameter("@kanaWriting", kanaReading)) == 1;
                 }
             }
             finally
@@ -195,8 +205,14 @@ namespace Kanji.Database.Dao
                 //connection = DaoConnection.Open(DaoConnectionEnum.KanjiDatabase);
                 connection = _connection;
 
-                connection.ExecuteNonQuery("UPDATE " + SqlHelper.Table_Vocab + " SET " + SqlHelper.Field_Vocab_FrequencyRank + "=@rank "
-                    + "WHERE " + SqlHelper.Field_Vocab_Id + "=@id", new DaoParameter("@rank", rank), new DaoParameter("@id", vocab.ID));
+                connection.ExecuteNonQuery(
+                    string.Format(
+                        "UPDATE {0} SET {1}=@rank WHERE {2}=@id",
+                        SqlHelper.Table_Vocab,
+                        SqlHelper.Field_Vocab_FrequencyRank,
+                        SqlHelper.Field_Vocab_Id),
+                    new DaoParameter("@rank", rank),
+                    new DaoParameter("@id", vocab.ID));
             }
             finally
             {
@@ -219,9 +235,10 @@ namespace Kanji.Database.Dao
             {
                 connection = DaoConnection.Open(DaoConnectionEnum.KanjiDatabase);
                 IEnumerable<NameValueCollection> vocabs = connection.Query(
-                      "SELECT v.* FROM " + SqlHelper.Table_Vocab + " v "
-                    + "WHERE v." + SqlHelper.Field_Vocab_KanjiWriting + "=@v "
-                    + "ORDER BY v." + SqlHelper.Field_Vocab_IsCommon + " DESC",
+                      string.Format("SELECT v.* FROM {0} v WHERE v.{1}=@v ORDER BY v.{2} DESC",
+                      SqlHelper.Table_Vocab,
+                      SqlHelper.Field_Vocab_KanjiWriting,
+                      SqlHelper.Field_Vocab_IsCommon),
                     new DaoParameter("@v", reading));
 
                 if (vocabs.Any())
@@ -237,9 +254,10 @@ namespace Kanji.Database.Dao
                 else
                 {
                     vocabs = connection.Query(
-                          "SELECT v.* FROM " + SqlHelper.Table_Vocab + " v "
-                        + "WHERE v." + SqlHelper.Field_Vocab_KanaWriting + "=@v "
-                        + "ORDER BY v." + SqlHelper.Field_Vocab_IsCommon + " DESC",
+                          string.Format("SELECT v.* FROM {0} v WHERE v.{1}=@v ORDER BY v.{2} DESC",
+                          SqlHelper.Table_Vocab,
+                          SqlHelper.Field_Vocab_KanaWriting,
+                          SqlHelper.Field_Vocab_IsCommon),
                         new DaoParameter("@v", reading));
 
                     VocabBuilder builder = new VocabBuilder();
@@ -279,8 +297,9 @@ namespace Kanji.Database.Dao
                 srsConnection.OpenAsync();
 
                 IEnumerable<NameValueCollection> vocabs = connection.Query(
-                      "SELECT * FROM " + SqlHelper.Table_Vocab + " WHERE "
-                    + SqlHelper.Field_Vocab_Id + "=@id",
+                      string.Format("SELECT * FROM {0} WHERE {1}=@id",
+                      SqlHelper.Table_Vocab,
+                      SqlHelper.Field_Vocab_Id),
                     new DaoParameter("@id", id));
 
                 if (vocabs.Any())
@@ -317,6 +336,13 @@ namespace Kanji.Database.Dao
         /// <param name="meaningFilter">Meaning filter. Only vocab containing
         /// this string as part of at least one of their meaning entries will
         /// be filtered in.</param>
+        /// <param name="categoryFilter">If not null, this category is used as the filter.</param>
+        /// <param name="jlptLevel">The JLPT level to filter
+        /// (1-5, where a lower value means it is not covered on the JLPT
+        /// and a higher value means that this filter will be ignored).</param>
+        /// <param name="wkLevel">The WaniKani level to filter
+        /// (1-60, where a higher value means it is not taught by WaniKani
+        /// and a lower value means that this filter will be ignored).</param>
         /// <param name="isCommonFirst">Indicates if common vocab should be
         /// presented first. If false, results are sorted only by the length
         /// of their writing (asc or desc depending on the parameter)</param>
@@ -326,20 +352,22 @@ namespace Kanji.Database.Dao
         /// come first.</param>
         /// <returns>Vocab entities matching the filters.</returns>
         public IEnumerable<VocabEntity> GetFilteredVocab(KanjiEntity kanji,
-            string readingFilter, string meaningFilter, bool isCommonFirst,
-            bool isShortWritingFirst)
+            string readingFilter, string meaningFilter, VocabCategory categoryFilter,
+            int jlptLevel, int wkLevel,
+			bool isCommonFirst, bool isShortWritingFirst)
         {
             List<DaoParameter> parameters = new List<DaoParameter>();
             string sqlFilterClauses = BuildVocabFilterClauses(parameters, kanji,
-                readingFilter, meaningFilter);
+                readingFilter, meaningFilter, categoryFilter, jlptLevel, wkLevel);
 
             string sortClause = "ORDER BY ";
             if (isCommonFirst)
             {
-                sortClause += "v." + SqlHelper.Field_Vocab_IsCommon + " DESC,";
+                sortClause += string.Format("v.{0} DESC,", SqlHelper.Field_Vocab_IsCommon);
             }
-            sortClause += "length(v." + SqlHelper.Field_Vocab_KanaWriting + ") "
-                + (isShortWritingFirst ? "ASC" : "DESC");
+            sortClause += string.Format("length(v.{0}) {1}",
+                SqlHelper.Field_Vocab_KanaWriting,
+                (isShortWritingFirst ? "ASC" : "DESC"));
 
             DaoConnection connection = null;
             DaoConnection srsConnection = null;
@@ -350,9 +378,10 @@ namespace Kanji.Database.Dao
                 srsConnection.OpenAsync();
 
                 IEnumerable<NameValueCollection> vocabs = connection.Query(
-                      "SELECT DISTINCT v.* FROM " + SqlHelper.Table_Vocab + " v "
-                    + sqlFilterClauses
-                    + sortClause,
+                      string.Format("SELECT DISTINCT v.* FROM {0} v {1}{2}",
+                      SqlHelper.Table_Vocab,
+                      sqlFilterClauses,
+                      sortClause),
                     parameters.ToArray());
 
                 VocabBuilder vocabBuilder = new VocabBuilder();
@@ -380,19 +409,20 @@ namespace Kanji.Database.Dao
         /// See <see cref="Kanji.Database.Dao.VocabDao.GetFilteredVocab"/>.
         /// Returns the results count.
         /// </summary>
-        public long GetFilteredVocabCount(KanjiEntity kanji, string readingFilter,
-            string meaningFilter)
+        public long GetFilteredVocabCount(KanjiEntity kanji,
+			string readingFilter, string meaningFilter, VocabCategory categoryFilter, int jlptLevel, int wkLevel)
         {
             List<DaoParameter> parameters = new List<DaoParameter>();
             string sqlFilterClauses = BuildVocabFilterClauses(parameters, kanji,
-                readingFilter, meaningFilter);
+                readingFilter, meaningFilter, categoryFilter, jlptLevel, wkLevel);
 
             using (DaoConnection connection
                 = DaoConnection.Open(DaoConnectionEnum.KanjiDatabase))
             {
                 return (long)connection.QueryScalar(
-                      "SELECT count(1) FROM " + SqlHelper.Table_Vocab + " v "
-                    + sqlFilterClauses,
+                      string.Format("SELECT count(1) FROM {0} v {1}",
+                      SqlHelper.Table_Vocab,
+                      sqlFilterClauses),
                     parameters.ToArray());
             }
         }
@@ -408,7 +438,7 @@ namespace Kanji.Database.Dao
             {
                 connection = DaoConnection.Open(DaoConnectionEnum.KanjiDatabase);
                 IEnumerable<NameValueCollection> results = connection.Query(
-                    "SELECT * FROM " + SqlHelper.Table_VocabCategory);
+                    string.Format("SELECT * FROM {0}", SqlHelper.Table_VocabCategory));
 
                 VocabCategoryBuilder categoryBuilder = new VocabCategoryBuilder();
                 foreach (NameValueCollection nvcCategory in results)
@@ -437,12 +467,13 @@ namespace Kanji.Database.Dao
             {
                 connection = DaoConnection.Open(DaoConnectionEnum.KanjiDatabase);
                 IEnumerable<NameValueCollection> results = connection.Query(
-                    "SELECT * FROM " + SqlHelper.Table_VocabCategory
-                    + " WHERE " + SqlHelper.Field_VocabCategory_Label + "=@label",
+                    string.Format("SELECT * FROM {0} WHERE {1}=@label",
+                    SqlHelper.Table_VocabCategory,
+                    SqlHelper.Field_VocabCategory_Label),
                     new DaoParameter("@label", label));
 
                 VocabCategoryBuilder categoryBuilder = new VocabCategoryBuilder();
-                if (results.Count() >= 1)
+                if (results.Any())
                 {
                     return categoryBuilder.BuildEntity(results.First(), null);
                 }
@@ -464,10 +495,43 @@ namespace Kanji.Database.Dao
         /// Builds and returns the vocab filter SQL clauses from the given
         /// filters.
         /// </summary>
-        internal string BuildVocabFilterClauses(List<DaoParameter> parameters,
-            KanjiEntity kanji, string readingFilter, string meaningFilter)
+        internal string BuildVocabFilterClauses(List<DaoParameter> parameters, 
+            KanjiEntity kanji,
+			string readingFilter, string meaningFilter, VocabCategory categoryFilter,
+            int jlptLevel, int wkLevel)
         {
-            bool isFiltered = false;
+            const int minJlptLevel = Levels.MinJlptLevel;
+            const int maxJlptLevel = Levels.MaxJlptLevel;
+            const int minWkLevel = Levels.MinWkLevel;
+            const int maxWkLevel = Levels.MaxWkLevel;
+
+            string sqlJlptFilter = string.Empty;
+            if (jlptLevel >= minJlptLevel && jlptLevel <= maxJlptLevel)
+            {
+                sqlJlptFilter = string.Format("v.{0}=@jlpt ",
+                    SqlHelper.Field_Vocab_JlptLevel);
+
+                parameters.Add(new DaoParameter("@jlpt", jlptLevel));
+            }
+            else if (jlptLevel < minJlptLevel)
+            {
+                sqlJlptFilter = string.Format("v.{0} IS NULL ",
+                    SqlHelper.Field_Vocab_JlptLevel);
+            }
+
+            string sqlWkFilter = string.Empty;
+            if (wkLevel >= minWkLevel && wkLevel <= maxWkLevel)
+            {
+                sqlWkFilter = string.Format("v.{0}=@wk ",
+                    SqlHelper.Field_Vocab_WaniKaniLevel);
+
+                parameters.Add(new DaoParameter("@wk", wkLevel));
+            }
+            else if (wkLevel > maxWkLevel)
+            {
+                sqlWkFilter = string.Format("v.{0} IS NULL ",
+                    SqlHelper.Field_Vocab_WaniKaniLevel);
+            }
 
             string sqlKanjiFilter = string.Empty;
             if (kanji != null)
@@ -477,9 +541,8 @@ namespace Kanji.Database.Dao
                 //
                 // WHERE v.KanjiWriting LIKE '%達%'
 
-                isFiltered = true;
-                sqlKanjiFilter = "WHERE v." + SqlHelper.Field_Vocab_KanjiWriting
-                    + " LIKE @kanji ";
+                sqlKanjiFilter = string.Format("v.{0} LIKE @kanji ",
+                    SqlHelper.Field_Vocab_KanjiWriting);
 
                 parameters.Add(new DaoParameter("@kanji", "%" + kanji.Character + "%"));
             }
@@ -493,12 +556,9 @@ namespace Kanji.Database.Dao
                 // WHERE v.KanaWriting LIKE '%かな%' OR
                 // v.KanjiWriting LIKE '%かな%'
 
-                sqlReadingFilter = isFiltered ? "AND " : "WHERE ";
-                isFiltered = true;
-
-                sqlReadingFilter += "(v." + SqlHelper.Field_Vocab_KanaWriting
-                    + " LIKE @reading OR v." + SqlHelper.Field_Vocab_KanjiWriting
-                    + " LIKE @reading) ";
+                sqlReadingFilter = string.Format("(v.{0} LIKE @reading OR v.{1} LIKE @reading) ",
+                    SqlHelper.Field_Vocab_KanaWriting,
+                    SqlHelper.Field_Vocab_KanjiWriting);
 
                 parameters.Add(new DaoParameter("@reading", "%" + readingFilter + "%"));
             }
@@ -510,33 +570,80 @@ namespace Kanji.Database.Dao
                 // Build the sql meaning filter clause and join clauses.
                 // Example of filter clause with meaningFilter="test" :
                 //
-                // WHERE vme.Meaning LIKE '%test%'
+                // WHERE vm.Meaning LIKE '%test%'
 
                 // First, build the join clause. This will be included before the filters.
-                sqlMeaningFilterJoins = "JOIN " + SqlHelper.Table_Vocab_VocabMeaning
-                    + " vvm ON (vvm." + SqlHelper.Field_Vocab_VocabMeaning_VocabId
-                    + "=v." + SqlHelper.Field_Vocab_Id + ") "
-                    + "JOIN " + SqlHelper.Table_VocabMeaning + " vm ON (vm."
-                    + SqlHelper.Field_VocabMeaning_Id + "=vvm."
-                    + SqlHelper.Field_Vocab_VocabMeaning_VocabMeaningId + ") ";
+                sqlMeaningFilterJoins = string.Format("JOIN {0} vvm ON (vvm.{1}=v.{2}) JOIN {3} vm ON (vm.{4}=vvm.{5}) ",
+                    SqlHelper.Table_Vocab_VocabMeaning,
+                    SqlHelper.Field_Vocab_VocabMeaning_VocabId,
+                    SqlHelper.Field_Vocab_Id,
+                    SqlHelper.Table_VocabMeaning,
+                    SqlHelper.Field_VocabMeaning_Id,
+                    SqlHelper.Field_Vocab_VocabMeaning_VocabMeaningId);
                 // Ouch... it looks kinda like an obfuscated string... Sorry.
                 // Basically, you just join the vocab to its meaning entries.
 
                 // Once the join clauses are done, build the filter itself.
-                // This will be applied as the last filter.
-                sqlMeaningFilter = isFiltered ? "AND " : "WHERE ";
-                isFiltered = true;
-
-                sqlMeaningFilter += "vm." + SqlHelper.Field_VocabMeaning_Meaning
-                    + " LIKE @meaning ";
+                sqlMeaningFilter = string.Format("vm.{0} LIKE @meaning ",
+                    SqlHelper.Field_VocabMeaning_Meaning);
 
                 parameters.Add(new DaoParameter("@meaning", "%" + meaningFilter + "%"));
             }
+			
+            string sqlCategoryFilterJoins = string.Empty;
+            string sqlCategoryFilter = string.Empty;
+            if (categoryFilter != null)
+            {
+                // Build the filter clause for the vocab category.
+                // Note that the category is actually associated either with the vocab itself or with a MEANING,
+                // so we need to grab any vocab which itself has said category, or of which ONE OF THE MEANINGS
+                // is of said category.
+                // Example of filter clause with category.ID=42 :
+                //
+                // WHERE vc.Categories_ID=42 OR mc.Categories_ID=42
 
-            return sqlMeaningFilterJoins
-                    + sqlKanjiFilter
-                    + sqlReadingFilter
-                    + sqlMeaningFilter;
+                sqlCategoryFilterJoins = string.Format(
+                    "JOIN {0} vc ON (vc.{1}=v.{2}) JOIN {3} vvm ON (vvm.{4}=v.{2}) JOIN {5} mc ON (mc.{6}=vvm.{7})",
+                    SqlHelper.Table_VocabCategory_Vocab,
+                    SqlHelper.Field_VocabCategory_Vocab_VocabId,
+                    SqlHelper.Field_VocabCategory_Id,
+                    SqlHelper.Table_Vocab_VocabMeaning,
+                    SqlHelper.Field_Vocab_VocabMeaning_VocabId,
+                    SqlHelper.Table_VocabMeaning_VocabCategory,
+                    SqlHelper.Field_VocabMeaning_VocabCategory_VocabMeaningId,
+                    SqlHelper.Field_Vocab_VocabMeaning_VocabMeaningId);
+                
+                sqlCategoryFilter = string.Format("vc.{0}=@cat OR mc.{1}=@cat ",
+                    SqlHelper.Field_VocabCategory_Vocab_VocabCategoryId,
+                    SqlHelper.Field_VocabMeaning_VocabCategory_VocabCategoryId);
+
+                parameters.Add(new DaoParameter("@cat", categoryFilter.ID));
+            }
+
+            string[] sqlArgs =
+            {
+                sqlJlptFilter,
+                sqlWkFilter,
+                sqlMeaningFilterJoins,
+                sqlCategoryFilterJoins,
+                sqlKanjiFilter,
+                sqlReadingFilter,
+                sqlMeaningFilter,
+                sqlCategoryFilter
+            };
+            
+            bool isFiltered = false;
+            for (int i = 0; i < sqlArgs.Length; i++)
+            {
+                string arg = sqlArgs[i];
+                if (string.IsNullOrEmpty(arg) || arg.StartsWith("JOIN"))
+                    continue;
+
+                sqlArgs[i] = (isFiltered ? "AND " : "WHERE ") + arg;
+                isFiltered = true;
+            }
+
+            return string.Concat(sqlArgs);
         }
 
         #endregion
@@ -550,10 +657,12 @@ namespace Kanji.Database.Dao
             VocabEntity vocab)
         {
             IEnumerable<NameValueCollection> results = connection.Query(
-                "SELECT k.* FROM " + SqlHelper.Table_Kanji_Vocab + " kv "
-                + "JOIN " + SqlHelper.Table_Kanji + " k ON (k."
-                + SqlHelper.Field_Kanji_Id + "=kv." + SqlHelper.Field_Kanji_Vocab_KanjiId
-                + ") WHERE kv." + SqlHelper.Field_Kanji_Vocab_VocabId + "=@vid",
+                string.Format("SELECT k.* FROM {0} kv JOIN {1} k ON (k.{2}=kv.{3}) WHERE kv.{4}=@vid",
+                SqlHelper.Table_Kanji_Vocab,
+                SqlHelper.Table_Kanji,
+                SqlHelper.Field_Kanji_Id,
+                SqlHelper.Field_Kanji_Vocab_KanjiId,
+                SqlHelper.Field_Kanji_Vocab_VocabId),
                 new DaoParameter("@vid", vocab.ID));
 
             KanjiBuilder kanjiBuilder = new KanjiBuilder();
@@ -573,9 +682,10 @@ namespace Kanji.Database.Dao
         private void IncludeVariants(DaoConnection connection, VocabEntity vocab)
         {
             IEnumerable<NameValueCollection> results = connection.Query(
-                "SELECT * FROM " + SqlHelper.Table_Vocab + " WHERE "
-                + SqlHelper.Field_Vocab_GroupId + "=@gid AND "
-                + SqlHelper.Field_Vocab_Id + "!=@id",
+                string.Format("SELECT * FROM {0} WHERE {1}=@gid AND {2}!=@id",
+                SqlHelper.Table_Vocab,
+                SqlHelper.Field_Vocab_GroupId,
+                SqlHelper.Field_Vocab_Id),
                 new DaoParameter("@gid", vocab.GroupId),
                 new DaoParameter("@id", vocab.ID));
 
@@ -592,11 +702,12 @@ namespace Kanji.Database.Dao
         private void IncludeCategories(DaoConnection connection, VocabEntity vocab)
         {
             IEnumerable<NameValueCollection> categories = connection.Query(
-                  "SELECT vc.* FROM " + SqlHelper.Table_VocabCategory_Vocab + " vcv "
-                + "JOIN " + SqlHelper.Table_VocabCategory + " vc ON (vcv."
-                + SqlHelper.Field_VocabCategory_Vocab_VocabCategoryId + "=vc."
-                + SqlHelper.Field_VocabCategory_Id + ") WHERE vcv."
-                + SqlHelper.Field_VocabCategory_Vocab_VocabId + "=@vid",
+                  string.Format("SELECT vc.* FROM {0} vcv JOIN {1} vc ON (vcv.{2}=vc.{3}) WHERE vcv.{4}=@vid",
+                  SqlHelper.Table_VocabCategory_Vocab,
+                  SqlHelper.Table_VocabCategory,
+                  SqlHelper.Field_VocabCategory_Vocab_VocabCategoryId,
+                  SqlHelper.Field_VocabCategory_Id,
+                  SqlHelper.Field_VocabCategory_Vocab_VocabId),
                 new DaoParameter("@vid", vocab.ID));
 
             VocabCategoryBuilder categoryBuilder = new VocabCategoryBuilder();
@@ -613,11 +724,12 @@ namespace Kanji.Database.Dao
         private void IncludeMeanings(DaoConnection connection, VocabEntity vocab)
         {
             IEnumerable<NameValueCollection> meanings = connection.Query(
-                  "SELECT vm.* FROM " + SqlHelper.Table_Vocab_VocabMeaning + " vvm "
-                + "JOIN " + SqlHelper.Table_VocabMeaning + " vm ON (vvm."
-                + SqlHelper.Field_Vocab_VocabMeaning_VocabMeaningId + "=vm."
-                + SqlHelper.Field_VocabMeaning_Id + ") WHERE vvm."
-                + SqlHelper.Field_Vocab_VocabMeaning_VocabId + "=@vid",
+                  string.Format("SELECT vm.* FROM {0} vvm JOIN {1} vm ON (vvm.{2}=vm.{3}) WHERE vvm.{4}=@vid",
+                  SqlHelper.Table_Vocab_VocabMeaning,
+                  SqlHelper.Table_VocabMeaning,
+                  SqlHelper.Field_Vocab_VocabMeaning_VocabMeaningId,
+                  SqlHelper.Field_VocabMeaning_Id,
+                  SqlHelper.Field_Vocab_VocabMeaning_VocabId),
                 new DaoParameter("@vid", vocab.ID));
 
             VocabMeaningBuilder meaningBuilder = new VocabMeaningBuilder();
@@ -635,11 +747,12 @@ namespace Kanji.Database.Dao
         private void IncludeMeaningCategories(DaoConnection connection, VocabMeaning meaning)
         {
             IEnumerable<NameValueCollection> categories = connection.Query(
-                  "SELECT vc.* FROM " + SqlHelper.Table_VocabMeaning_VocabCategory + " vmvc "
-                + "JOIN " + SqlHelper.Table_VocabCategory + " vc ON (vmvc."
-                + SqlHelper.Field_VocabMeaning_VocabCategory_VocabCategoryId + "=vc."
-                + SqlHelper.Field_VocabCategory_Id + ") WHERE vmvc."
-                + SqlHelper.Field_VocabMeaning_VocabCategory_VocabMeaningId + "=@mid",
+                  string.Format("SELECT vc.* FROM {0} vmvc JOIN {1} vc ON (vmvc.{2}=vc.{3}) WHERE vmvc.{4}=@mid",
+                  SqlHelper.Table_VocabMeaning_VocabCategory,
+                  SqlHelper.Table_VocabCategory,
+                  SqlHelper.Field_VocabMeaning_VocabCategory_VocabCategoryId,
+                  SqlHelper.Field_VocabCategory_Id,
+                  SqlHelper.Field_VocabMeaning_VocabCategory_VocabMeaningId),
                 new DaoParameter("@mid", meaning.ID));
 
             VocabCategoryBuilder categoryBuilder = new VocabCategoryBuilder();
@@ -661,9 +774,9 @@ namespace Kanji.Database.Dao
                 : vocab.KanjiWriting;
 
             IEnumerable<NameValueCollection> nvcEntries = connection.Query(
-                "SELECT * "
-                + "FROM " + SqlHelper.Table_SrsEntry + " srs "
-                + "WHERE srs." + SqlHelper.Field_SrsEntry_AssociatedVocab + "=@k",
+                string.Format("SELECT * FROM {0} srs WHERE srs.{1}=@k",
+                SqlHelper.Table_SrsEntry,
+                SqlHelper.Field_SrsEntry_AssociatedVocab),
                 new DaoParameter("@k", value));
 
             SrsEntryBuilder srsEntryBuilder = new SrsEntryBuilder();

--- a/Kanji.Database/Extensions/NameValueCollectionExtensions.cs
+++ b/Kanji.Database/Extensions/NameValueCollectionExtensions.cs
@@ -142,7 +142,8 @@ namespace Kanji.Database.Extensions
                 long numericValue = 0;
                 if (long.TryParse(value, out numericValue))
                 {
-                    return new DateTime(numericValue, DateTimeKind.Utc);
+                    // The DB should store it as UTC, but we need to work with it as local time.
+                    return new DateTime(numericValue, DateTimeKind.Utc).ToLocalTime();
                 }
             }
 

--- a/Kanji.Database/Helpers/SqlHelper.cs
+++ b/Kanji.Database/Helpers/SqlHelper.cs
@@ -11,25 +11,25 @@ namespace Kanji.Database.Helpers
 
         #region Main
         
-        public static readonly string Table_Kanji = "KanjiSet";
-        public static readonly string Table_Radical = "RadicalSet";
-        public static readonly string Table_KanjiMeaning = "KanjiMeaningSet";
-        public static readonly string Table_Vocab = "VocabSet";
-        public static readonly string Table_VocabCategory = "VocabCategorySet";
-        public static readonly string Table_VocabMeaning = "VocabMeaningSet";
-        public static readonly string Table_KanjiStrokes = "KanjiStrokes";
+        public const string Table_Kanji = "KanjiSet";
+        public const string Table_Radical = "RadicalSet";
+        public const string Table_KanjiMeaning = "KanjiMeaningSet";
+        public const string Table_Vocab = "VocabSet";
+        public const string Table_VocabCategory = "VocabCategorySet";
+        public const string Table_VocabMeaning = "VocabMeaningSet";
+        public const string Table_KanjiStrokes = "KanjiStrokes";
 
-        public static readonly string Table_SrsEntry = "SrsEntrySet";
+        public const string Table_SrsEntry = "SrsEntrySet";
 
         #endregion
 
         #region Link tables
 
-        public static readonly string Table_Kanji_Radical = "KanjiRadical";
-        public static readonly string Table_VocabMeaning_VocabCategory = "VocabMeaningVocabCategory";
-        public static readonly string Table_Vocab_VocabMeaning = "VocabEntityVocabMeaning";
-        public static readonly string Table_VocabCategory_Vocab = "VocabCategoryVocabEntity";
-        public static readonly string Table_Kanji_Vocab = "KanjiEntityVocabEntity";
+        public const string Table_Kanji_Radical = "KanjiRadical";
+        public const string Table_VocabMeaning_VocabCategory = "VocabMeaningVocabCategory";
+        public const string Table_Vocab_VocabMeaning = "VocabEntityVocabMeaning";
+        public const string Table_VocabCategory_Vocab = "VocabCategoryVocabEntity";
+        public const string Table_Kanji_Vocab = "KanjiEntityVocabEntity";
 
         #endregion
 
@@ -39,129 +39,129 @@ namespace Kanji.Database.Helpers
 
         #region Kanji table
 
-        public static readonly string Field_Kanji_Id = "ID";
-        public static readonly string Field_Kanji_Character = "Character";
-        public static readonly string Field_Kanji_StrokeCount = "StrokeCount";
-        public static readonly string Field_Kanji_Grade = "Grade";
-        public static readonly string Field_Kanji_MostUsedRank = "MostUsedRank";
-        public static readonly string Field_Kanji_JlptLevel = "JlptLevel";
-        public static readonly string Field_Kanji_OnYomi = "OnYomi";
-        public static readonly string Field_Kanji_KunYomi = "KunYomi";
-        public static readonly string Field_Kanji_Nanori = "Nanori";
-        public static readonly string Field_Kanji_UnicodeValue = "UnicodeValue";
-        public static readonly string Field_Kanji_NewspaperRank = "NewspaperRank";
-        public static readonly string Field_Kanji_WaniKaniLevel = "WkLevel";
+        public const string Field_Kanji_Id = "ID";
+        public const string Field_Kanji_Character = "Character";
+        public const string Field_Kanji_StrokeCount = "StrokeCount";
+        public const string Field_Kanji_Grade = "Grade";
+        public const string Field_Kanji_MostUsedRank = "MostUsedRank";
+        public const string Field_Kanji_JlptLevel = "JlptLevel";
+        public const string Field_Kanji_OnYomi = "OnYomi";
+        public const string Field_Kanji_KunYomi = "KunYomi";
+        public const string Field_Kanji_Nanori = "Nanori";
+        public const string Field_Kanji_UnicodeValue = "UnicodeValue";
+        public const string Field_Kanji_NewspaperRank = "NewspaperRank";
+        public const string Field_Kanji_WaniKaniLevel = "WkLevel";
 
         #endregion
 
         #region Radical table
 
-        public static readonly string Field_Radical_Id = "ID";
-        public static readonly string Field_Radical_Character = "Character";
+        public const string Field_Radical_Id = "ID";
+        public const string Field_Radical_Character = "Character";
 
         #endregion
 
         #region KanjiMeaning table
 
-        public static readonly string Field_KanjiMeaning_Id = "ID";
-        public static readonly string Field_KanjiMeaning_Language = "Language";
-        public static readonly string Field_KanjiMeaning_Meaning = "Meaning";
-        public static readonly string Field_KanjiMeaning_KanjiId = "Kanji_ID";
+        public const string Field_KanjiMeaning_Id = "ID";
+        public const string Field_KanjiMeaning_Language = "Language";
+        public const string Field_KanjiMeaning_Meaning = "Meaning";
+        public const string Field_KanjiMeaning_KanjiId = "Kanji_ID";
 
         #endregion
 
         #region Vocab table
 
-        public static readonly string Field_Vocab_Id = "ID";
-        public static readonly string Field_Vocab_KanjiWriting = "KanjiWriting";
-        public static readonly string Field_Vocab_KanaWriting = "KanaWriting";
-        public static readonly string Field_Vocab_IsCommon = "IsCommon";
-        public static readonly string Field_Vocab_FrequencyRank = "FrequencyRank";
-        public static readonly string Field_Vocab_Furigana = "Furigana";
-        public static readonly string Field_Vocab_JlptLevel = "JlptLevel";
-        public static readonly string Field_Vocab_WaniKaniLevel = "WkLevel";
-        public static readonly string Field_Vocab_WikipediaRank = "WikiRank";
-        public static readonly string Field_Vocab_GroupId = "GroupId";
-        public static readonly string Field_Vocab_IsMain = "IsMain";
+        public const string Field_Vocab_Id = "ID";
+        public const string Field_Vocab_KanjiWriting = "KanjiWriting";
+        public const string Field_Vocab_KanaWriting = "KanaWriting";
+        public const string Field_Vocab_IsCommon = "IsCommon";
+        public const string Field_Vocab_FrequencyRank = "FrequencyRank";
+        public const string Field_Vocab_Furigana = "Furigana";
+        public const string Field_Vocab_JlptLevel = "JlptLevel";
+        public const string Field_Vocab_WaniKaniLevel = "WkLevel";
+        public const string Field_Vocab_WikipediaRank = "WikiRank";
+        public const string Field_Vocab_GroupId = "GroupId";
+        public const string Field_Vocab_IsMain = "IsMain";
 
         #endregion
 
         #region VocabCategory table
 
-        public static readonly string Field_VocabCategory_Id = "ID";
-        public static readonly string Field_VocabCategory_ShortName = "ShortName";
-        public static readonly string Field_VocabCategory_Label = "Label";
+        public const string Field_VocabCategory_Id = "ID";
+        public const string Field_VocabCategory_ShortName = "ShortName";
+        public const string Field_VocabCategory_Label = "Label";
 
         #endregion
 
         #region VocabMeaning table
 
-        public static readonly string Field_VocabMeaning_Id = "ID";
-        public static readonly string Field_VocabMeaning_Meaning = "Meaning";
+        public const string Field_VocabMeaning_Id = "ID";
+        public const string Field_VocabMeaning_Meaning = "Meaning";
 
         #endregion
 
         #region Kanji-Radical table
 
-        public static readonly string Field_Kanji_Radical_KanjiId = "Kanji_ID";
-        public static readonly string Field_Kanji_Radical_RadicalId = "Radicals_ID";
+        public const string Field_Kanji_Radical_KanjiId = "Kanji_ID";
+        public const string Field_Kanji_Radical_RadicalId = "Radicals_ID";
 
         #endregion
 
         #region VocabMeaning-VocabCategory table
 
-        public static readonly string Field_VocabMeaning_VocabCategory_VocabCategoryId = "Categories_ID";
-        public static readonly string Field_VocabMeaning_VocabCategory_VocabMeaningId = "VocabMeaningVocabCategory_VocabCategory_ID";
+        public const string Field_VocabMeaning_VocabCategory_VocabCategoryId = "Categories_ID";
+        public const string Field_VocabMeaning_VocabCategory_VocabMeaningId = "VocabMeaningVocabCategory_VocabCategory_ID";
 
         #endregion
 
         #region Vocab-VocabMeaning table
 
-        public static readonly string Field_Vocab_VocabMeaning_VocabId = "VocabEntity_ID";
-        public static readonly string Field_Vocab_VocabMeaning_VocabMeaningId = "Meanings_ID";
+        public const string Field_Vocab_VocabMeaning_VocabId = "VocabEntity_ID";
+        public const string Field_Vocab_VocabMeaning_VocabMeaningId = "Meanings_ID";
 
         #endregion
 
         #region VocabCategory-Vocab table
 
-        public static readonly string Field_VocabCategory_Vocab_VocabCategoryId = "Categories_ID";
-        public static readonly string Field_VocabCategory_Vocab_VocabId = "VocabCategoryVocabEntity_VocabCategory_ID";
+        public const string Field_VocabCategory_Vocab_VocabCategoryId = "Categories_ID";
+        public const string Field_VocabCategory_Vocab_VocabId = "VocabCategoryVocabEntity_VocabCategory_ID";
 
         #endregion
 
         #region Kanji-Vocab table
 
-        public static readonly string Field_Kanji_Vocab_KanjiId = "Kanji_ID";
-        public static readonly string Field_Kanji_Vocab_VocabId = "Vocabs_ID";
+        public const string Field_Kanji_Vocab_KanjiId = "Kanji_ID";
+        public const string Field_Kanji_Vocab_VocabId = "Vocabs_ID";
 
         #endregion
 
         #region SrsEntry table
 
-        public static readonly string Field_SrsEntry_Id = "ID";
-        public static readonly string Field_SrsEntry_CreationDate = "CreationDate";
-        public static readonly string Field_SrsEntry_NextAnswerDate = "NextAnswerDate";
-        public static readonly string Field_SrsEntry_Meanings = "Meanings";
-        public static readonly string Field_SrsEntry_Readings = "Readings";
-        public static readonly string Field_SrsEntry_CurrentGrade = "CurrentGrade";
-        public static readonly string Field_SrsEntry_FailureCount = "FailureCount";
-        public static readonly string Field_SrsEntry_SuccessCount = "SuccessCount";
-        public static readonly string Field_SrsEntry_AssociatedVocab = "AssociatedVocab";
-        public static readonly string Field_SrsEntry_AssociatedKanji = "AssociatedKanji";
-        public static readonly string Field_SrsEntry_MeaningNote = "MeaningNote";
-        public static readonly string Field_SrsEntry_ReadingNote = "ReadingNote";
-        public static readonly string Field_SrsEntry_SuspensionDate = "SuspensionDate";
-        public static readonly string Field_SrsEntry_Tags = "Tags";
-        public static readonly string Field_SrsEntry_LastUpdateDate = "LastUpdateDate";
-        public static readonly string Field_SrsEntry_IsDeleted = "IsDeleted";
-        public static readonly string Field_SrsEntry_ServerId = "ServerId";
+        public const string Field_SrsEntry_Id = "ID";
+        public const string Field_SrsEntry_CreationDate = "CreationDate";
+        public const string Field_SrsEntry_NextAnswerDate = "NextAnswerDate";
+        public const string Field_SrsEntry_Meanings = "Meanings";
+        public const string Field_SrsEntry_Readings = "Readings";
+        public const string Field_SrsEntry_CurrentGrade = "CurrentGrade";
+        public const string Field_SrsEntry_FailureCount = "FailureCount";
+        public const string Field_SrsEntry_SuccessCount = "SuccessCount";
+        public const string Field_SrsEntry_AssociatedVocab = "AssociatedVocab";
+        public const string Field_SrsEntry_AssociatedKanji = "AssociatedKanji";
+        public const string Field_SrsEntry_MeaningNote = "MeaningNote";
+        public const string Field_SrsEntry_ReadingNote = "ReadingNote";
+        public const string Field_SrsEntry_SuspensionDate = "SuspensionDate";
+        public const string Field_SrsEntry_Tags = "Tags";
+        public const string Field_SrsEntry_LastUpdateDate = "LastUpdateDate";
+        public const string Field_SrsEntry_IsDeleted = "IsDeleted";
+        public const string Field_SrsEntry_ServerId = "ServerId";
 
         #endregion
 
         #region KanjiStrokes tables
 
-        public static readonly string Field_KanjiStrokes_Id = "ID";
-        public static readonly string Field_KanjiStrokes_FramesSvg = "FramesSvg";
+        public const string Field_KanjiStrokes_Id = "ID";
+        public const string Field_KanjiStrokes_FramesSvg = "FramesSvg";
 
         #endregion
 

--- a/Kanji.Database/Kanji.Database.csproj
+++ b/Kanji.Database/Kanji.Database.csproj
@@ -105,10 +105,12 @@
     <Compile Include="Models\FilterClauses\Concrete\SrsEntryFilterClauses.cs" />
     <Compile Include="Models\FilterClauses\MultiFieldComparisonFilterClause.cs" />
     <Compile Include="Models\FilterClauses\MultiFieldFilterClause.cs" />
+    <Compile Include="Models\FilterClauses\SingleFieldIntegerFilterClause.cs" />
     <Compile Include="Models\FilterClauses\StringFieldSearchFilterClause.cs" />
     <Compile Include="Models\FilterClauses\NullFieldFilterClause.cs" />
     <Compile Include="Models\FilterClauses\SingleFieldFilterClause.cs" />
     <Compile Include="Models\FilterClauses\SingleFieldComparisonFilterClause.cs" />
+    <Compile Include="Models\FilterClauses\VocabCategorySearchFilterClause.cs" />
     <Compile Include="Models\RadicalGroup.cs" />
     <Compile Include="Models\FilterClause.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Kanji.Database/Models/FilterClauses/Concrete/SrsEntryFilterClauses.cs
+++ b/Kanji.Database/Models/FilterClauses/Concrete/SrsEntryFilterClauses.cs
@@ -57,6 +57,23 @@ namespace Kanji.Database.Models
             : base("se." + SqlHelper.Field_SrsEntry_CurrentGrade) { }
     }
 
+    public sealed class SrsEntryFilterCategoryClause : VocabCategorySearchFilterClause
+    {
+        
+    }
+
+    public sealed class SrsEntryFilterJlptLevelClause : SingleFieldIntegerFilterClause
+    {
+        public SrsEntryFilterJlptLevelClause()
+            : base("se." + SqlHelper.Field_Vocab_JlptLevel) { }
+    }
+
+    public sealed class SrsEntryFilterWkLevelClause : SingleFieldIntegerFilterClause
+    {
+        public SrsEntryFilterWkLevelClause()
+            : base("se." + SqlHelper.Field_Vocab_WaniKaniLevel) { }
+    }
+
     public sealed class SrsEntryFilterNotesClause : StringFieldSearchFilterClause
     {
         public SrsEntryFilterNotesClause()

--- a/Kanji.Database/Models/FilterClauses/SingleFieldIntegerFilterClause.cs
+++ b/Kanji.Database/Models/FilterClauses/SingleFieldIntegerFilterClause.cs
@@ -1,0 +1,50 @@
+﻿using System.Collections.Generic;
+using Kanji.Database.Dao;
+
+namespace Kanji.Database.Models
+{
+    public class SingleFieldIntegerFilterClause : SingleFieldFilterClause
+    {
+        #region Properties
+
+        public int? Value { get; set; }
+        
+		/// <summary>
+		/// Gets or sets a boolean defining whether the filter should include
+		/// or exclude results.
+		/// </summary>
+		public bool IsInclude { get; set; }
+
+        #endregion
+
+        #region Constructors
+
+        public SingleFieldIntegerFilterClause(string fieldName)
+            : base(fieldName)
+        {
+            IsInclude = true;
+        }
+
+        #endregion
+
+        #region Methods
+
+        protected override string DoGetSqlWhereClause(List<DaoParameter> parameters)
+        {
+            if (!Value.HasValue)
+			{
+				return null;
+			}
+
+			string clause = string.Empty;
+
+			string paramIdContains = GetUniqueParamId();
+			parameters.Add(new DaoParameter(paramIdContains, Value.Value));
+
+			clause += _fieldName + "=" + paramIdContains;
+			return (IsInclude ? string.Empty : "NOT ") + "(" + clause + ")";
+        }
+
+        #endregion
+    }
+}

--- a/Kanji.Database/Models/FilterClauses/VocabCategorySearchFilterClause.cs
+++ b/Kanji.Database/Models/FilterClauses/VocabCategorySearchFilterClause.cs
@@ -1,0 +1,51 @@
+﻿using System.Collections.Generic;
+using Kanji.Database.Dao;
+using Kanji.Database.Helpers;
+
+namespace Kanji.Database.Models
+{
+	public abstract class VocabCategorySearchFilterClause : SingleFieldFilterClause
+	{
+		#region Properties
+
+		public long ID { get; set; }
+		
+		/// <summary>
+		/// Gets or sets a boolean defining whether the filter should include
+		/// or exclude results.
+		/// </summary>
+		public bool IsInclude { get; set; }
+
+		#endregion
+
+		#region Constructors
+
+		public VocabCategorySearchFilterClause()
+            : base(SqlHelper.Table_Vocab + SqlHelper.Field_VocabCategory_Id)
+		{
+			IsInclude = true;
+		}
+
+		#endregion
+
+		#region Methods
+
+		protected override string DoGetSqlWhereClause(List<DaoParameter> parameters)
+		{
+			if (ID < 0)
+			{
+				return _fieldName + " > 0";
+			}
+
+			string clause = string.Empty;
+
+			string paramIdContains = GetUniqueParamId();
+			parameters.Add(new DaoParameter(paramIdContains, ID));
+
+			clause += _fieldName + "=" + paramIdContains;
+			return (IsInclude ? string.Empty : "NOT ") + "(" + clause + ")";
+		}
+
+		#endregion
+	}
+}

--- a/Kanji.Interface/Business/FilteredKanjiIterator.cs
+++ b/Kanji.Interface/Business/FilteredKanjiIterator.cs
@@ -51,7 +51,7 @@ namespace Kanji.Interface.Business
             RadicalGroup[] radicalGroups = filter.Radicals.SelectMany(r => r.Reference.RadicalGroups).ToArray();
 
             return _kanjiDao.GetFilteredKanji(radicalGroups, filter.TextFilter, meaningFilter,
-                anyReadingFilter, onYomiFilter, kunYomiFilter, nanoriFilter);
+                anyReadingFilter, onYomiFilter, kunYomiFilter, nanoriFilter, filter.JlptLevel, filter.WkLevel);
         }
 
         /// <summary>
@@ -73,7 +73,7 @@ namespace Kanji.Interface.Business
             RadicalGroup[] radicalGroups = filter.Radicals.SelectMany(r => r.Reference.RadicalGroups).ToArray();
 
             return (int)_kanjiDao.GetFilteredKanjiCount(radicalGroups, filter.TextFilter, meaningFilter,
-                anyReadingFilter, onYomiFilter, kunYomiFilter, nanoriFilter);
+                anyReadingFilter, onYomiFilter, kunYomiFilter, nanoriFilter, filter.JlptLevel, filter.WkLevel);
         }
 
         /// <summary>

--- a/Kanji.Interface/Business/FilteredVocabIterator.cs
+++ b/Kanji.Interface/Business/FilteredVocabIterator.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Kanji.Common.Utility;
 using Kanji.Database.Dao;
 using Kanji.Database.Entities;
 using Kanji.Interface.Models;
@@ -43,6 +44,7 @@ namespace Kanji.Interface.Business
                 foreach (VocabEntity vocab in _vocabDao.GetFilteredVocab(
                     filter.Kanji.FirstOrDefault(),
                     filter.ReadingString, filter.MeaningString,
+                    filter.Category, filter.JlptLevel, filter.WkLevel,
                     filter.IsCommonFirst, filter.IsShortReadingFirst))
                 {
                     yield return vocab;
@@ -59,7 +61,8 @@ namespace Kanji.Interface.Business
                 VocabFilter filter = (VocabFilter)_currentFilter;
 
                 return (int)_vocabDao.GetFilteredVocabCount(filter.Kanji.FirstOrDefault(),
-                    filter.ReadingString, filter.MeaningString);
+                    filter.ReadingString, filter.MeaningString,
+                    filter.Category, filter.JlptLevel, filter.WkLevel);
             }
 
             return 0;

--- a/Kanji.Interface/Business/RadicalBusiness.cs
+++ b/Kanji.Interface/Business/RadicalBusiness.cs
@@ -44,7 +44,7 @@ namespace Kanji.Interface.Business
             RadicalGroup[] radicalGroups = filter.Radicals.SelectMany(r => r.Reference.RadicalGroups).ToArray();
 
             return _radicalDao.GetAvailableRadicals(radicalGroups, filter.TextFilter, meaningFilter,
-                anyReadingFilter, onYomiFilter, kunYomiFilter, nanoriFilter)
+                anyReadingFilter, onYomiFilter, kunYomiFilter, nanoriFilter, filter.JlptLevel, filter.WkLevel)
                 .ToArray();
         }
 

--- a/Kanji.Interface/Converters/DateTimeToStringConverter.cs
+++ b/Kanji.Interface/Converters/DateTimeToStringConverter.cs
@@ -29,7 +29,10 @@ namespace Kanji.Interface.Converters
 
             if (v.HasValue)
             {
-                DateTime t = v.Value.ToLocalTime();
+                // If Kind is Unspecified, we want it treated as Local.
+                // This is because generally, Unspecified is only used for DateTime objects
+                // returned from the DatePicker control.
+                DateTime t = v.Value.Kind == DateTimeKind.Utc ? v.Value.ToLocalTime() : v.Value;
 
                 // Get the conversion type.
                 DateTimeToStringConversionEnum conversion;
@@ -51,7 +54,7 @@ namespace Kanji.Interface.Converters
                 {
                     // Get the difference.
                     TimeSpan diff = t - DateTime.Now;
-                    bool negate = diff.Ticks < 0;
+                    bool negate = diff.Ticks < 0L;
 
                     // Negate the TimeSpan if it is negative.
                     if (negate)

--- a/Kanji.Interface/Converters/NumberToJlptLevelConverter.cs
+++ b/Kanji.Interface/Converters/NumberToJlptLevelConverter.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Data;
+using Kanji.Common.Utility;
+
+namespace Kanji.Interface.Converters
+{
+    class NumberToJlptLevelConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            if (value == null)
+            {
+                return string.Empty;
+            }
+            
+            if (value is long || value is ulong ||
+                value is int || value is uint ||
+                value is short || value is ushort ||
+                value is sbyte || value is byte ||
+                value is double || value is float)
+            {
+                int actualValue = unchecked ((int)Math.Round((double)value));
+
+                if (actualValue < Levels.MinJlptLevel)
+                {
+                    return "Not in JLPT";
+                }
+                if (actualValue > Levels.MaxJlptLevel)
+                {
+                    return "[Ignore]";
+                }
+
+                switch (actualValue)
+                {
+                    case 1:
+                        return "N1";
+                    case 2:
+                        return "N2";
+                    case 3:
+                        return "N3";
+                    case 4:
+                        return "N4";
+                    case 5:
+                        return "N5";
+                    default:
+                        throw new InvalidOperationException("Unhandled JLPT Level");
+                }
+            }
+            else
+            {
+                throw new ArgumentException("The value provided must be an integer.");
+            }
+        }
+        
+        public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Kanji.Interface/Converters/NumberToWkLevelConverter.cs
+++ b/Kanji.Interface/Converters/NumberToWkLevelConverter.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Data;
+using Kanji.Common.Utility;
+
+namespace Kanji.Interface.Converters
+{
+    class NumberToWkConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            if (value == null)
+            {
+                return string.Empty;
+            }
+
+            if (value is long || value is ulong ||
+                value is int || value is uint ||
+                value is short || value is ushort ||
+                value is sbyte || value is byte ||
+                value is double || value is float)
+            {
+                int actualValue = unchecked ((int)Math.Round((double)value));
+                switch (actualValue)
+                {
+                    case 0:
+                        return "[Ignore]";
+                    default:
+                        return actualValue >= Levels.MinWkLevel && actualValue <= Levels.MaxWkLevel ? string.Format("WK {0}", actualValue) : "Not taught on WK";
+                }
+            }
+            else
+            {
+                throw new ArgumentException("The value provided must be an integer.");
+            }
+        }
+        
+        public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Kanji.Interface/Converters/StringAppendConverter.cs
+++ b/Kanji.Interface/Converters/StringAppendConverter.cs
@@ -12,9 +12,13 @@ namespace Kanji.Interface.Converters
         public object Convert(object[] values, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
             string output = string.Empty;
-            foreach (object value in values)
+            if (values != null)
             {
-                output += value.ToString();
+                foreach (object value in values)
+                {
+					if (value != null)
+						output += value.ToString();
+                }
             }
 
             return output;

--- a/Kanji.Interface/Converters/VocabCategoriesToStringConverter.cs
+++ b/Kanji.Interface/Converters/VocabCategoriesToStringConverter.cs
@@ -411,10 +411,6 @@ namespace Kanji.Interface.Converters
                     return CategoryDictionary[category.ID].Label;
                 }
             }
-            else if (value != null)
-            {
-                throw new ArgumentException("This converter takes one or more VocabCategory entities.");
-            }
 
             return null;
         }

--- a/Kanji.Interface/Data/Resources/HomePageChangelog.xml
+++ b/Kanji.Interface/Data/Resources/HomePageChangelog.xml
@@ -1,6 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <ArrayOfChangelogEntry xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <ChangelogEntry>
+    <Version>1.3</Version>
+    <Title>Filter vocab/kanji by JLPT/WK level</Title>
+    <Description>You can now filter vocabulary words and kanji by the level at which they are taught on the Kanji learning website WaniKani and the JLPT level at which they are used.
+
+Moreover, vocabulary words can now be filtered by their categories (such as mathematical terms and computer-related terms).
+Note that a lot of categories currently exist, but many of them are not used.</Description>
+  </ChangelogEntry>
+  <ChangelogEntry>
     <Version>1.2</Version>
     <Title>Quick add for vocab</Title>
     <Description>You can now add vocab to your SRS list in one click using the Quick add button.</Description>

--- a/Kanji.Interface/Kanji.Interface.csproj
+++ b/Kanji.Interface/Kanji.Interface.csproj
@@ -182,6 +182,8 @@
     <Compile Include="Converters\DateTimeToStringConverter.cs" />
     <Compile Include="Converters\EnumBooleanConverter.cs" />
     <Compile Include="Converters\ExtendedVocabToVariantListConverter.cs" />
+    <Compile Include="Converters\NumberToWkLevelConverter.cs" />
+    <Compile Include="Converters\NumberToJlptLevelConverter.cs" />
     <Compile Include="Converters\IsFirstItemInContainerConverter.cs" />
     <Compile Include="Converters\JlptLevelToBrushConverter.cs" />
     <Compile Include="Converters\KanjiToReadingListConverter.cs" />
@@ -233,6 +235,9 @@
     <Compile Include="ViewModels\Partial\Import\ImportDuplicateOptionsViewModel.cs" />
     <Compile Include="ViewModels\Partial\Import\ImportOverviewViewModel.cs" />
     <Compile Include="ViewModels\Partial\Import\ImportProgressViewModel.cs" />
+    <Compile Include="ViewModels\Partial\Common\Filters\CategoryFilterViewModel.cs" />
+    <Compile Include="ViewModels\Partial\Common\Filters\JlptLevelFilterViewModel.cs" />
+    <Compile Include="ViewModels\Partial\Common\Filters\WkLevelFilterViewModel.cs" />
     <Compile Include="ViewModels\Partial\Srs\SrsTimingViewModel.cs" />
     <Compile Include="Models\Import\ImportTimingMode.cs" />
     <Compile Include="Models\SettingsCategoryEnum.cs" />
@@ -505,6 +510,15 @@
     </Compile>
     <Compile Include="Views\Partial\Settings\Pages\VocabSettingsControl.xaml.cs">
       <DependentUpon>VocabSettingsControl.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Views\Partial\Common\Filters\WkLevelFilterControl.xaml.cs">
+      <DependentUpon>WkLevelFilterControl.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Views\Partial\Common\Filters\JlptLevelFilterControl.xaml.cs">
+      <DependentUpon>JlptLevelFilterControl.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Views\Partial\Common\Filters\CategoryFilterControl.xaml.cs">
+      <DependentUpon>CategoryFilterControl.xaml</DependentUpon>
     </Compile>
     <Compile Include="Views\Partial\Srs\SrsReviewControl.xaml.cs">
       <DependentUpon>SrsReviewControl.xaml</DependentUpon>
@@ -836,6 +850,18 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="Views\Partial\Common\Filters\WkLevelFilterControl.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Views\Partial\Common\Filters\JlptLevelFilterControl.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Views\Partial\Common\Filters\CategoryFilterControl.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
     <Page Include="Views\Partial\Srs\SrsReviewControl.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -1012,7 +1038,7 @@
   <ItemGroup>
     <BootstrapperPackage Include=".NETFramework,Version=v4.0">
       <Visible>False</Visible>
-      <ProductName>Microsoft .NET Framework 4 %28x86 et x64%29</ProductName>
+      <ProductName>Microsoft .NET Framework 4 %28x86 and x64%29</ProductName>
       <Install>true</Install>
     </BootstrapperPackage>
     <BootstrapperPackage Include="Microsoft.Net.Client.3.5">
@@ -1027,7 +1053,7 @@
     </BootstrapperPackage>
     <BootstrapperPackage Include="Microsoft.Windows.Installer.4.5">
       <Visible>False</Visible>
-      <ProductName>Windows Installer 4.5</ProductName>
+      <ProductName>Windows Installer 4.5</ProductName>
       <Install>true</Install>
     </BootstrapperPackage>
   </ItemGroup>

--- a/Kanji.Interface/Models/KanjiFilter.cs
+++ b/Kanji.Interface/Models/KanjiFilter.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Kanji.Common.Utility;
 using Kanji.Database.Entities;
 
 namespace Kanji.Interface.Models
@@ -31,6 +32,16 @@ namespace Kanji.Interface.Models
         /// which do not contain all of them.
         /// </summary>
         public FilteringRadical[] Radicals { get; set; }
+        
+        /// <summary>
+        /// Gets or sets the JLPT level vocab filter.
+        /// </summary>
+        public int JlptLevel { get; set; }
+
+        /// <summary>
+        /// Gets or sets the WaniKani level vocab filter.
+        /// </summary>
+        public int WkLevel { get; set; }
 
         public KanjiFilter()
         {
@@ -41,6 +52,8 @@ namespace Kanji.Interface.Models
         {
             return string.IsNullOrWhiteSpace(MainFilter)
                 && string.IsNullOrWhiteSpace(TextFilter)
+                && JlptLevel > Levels.MaxJlptLevel
+                && WkLevel < Levels.MinWkLevel
                 && !Radicals.Any();
         }
 
@@ -52,7 +65,9 @@ namespace Kanji.Interface.Models
                 MainFilter = this.MainFilter,
                 MainFilterMode = this.MainFilterMode,
                 TextFilter = this.TextFilter,
-                Radicals = (FilteringRadical[])this.Radicals.Clone()
+                Radicals = (FilteringRadical[])this.Radicals.Clone(),
+                JlptLevel = this.JlptLevel,
+                WkLevel = this.WkLevel
             };
         }
     }

--- a/Kanji.Interface/Models/VocabFilter.cs
+++ b/Kanji.Interface/Models/VocabFilter.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Kanji.Common.Utility;
 using Kanji.Database.Entities;
 
 namespace Kanji.Interface.Models
@@ -12,6 +13,8 @@ namespace Kanji.Interface.Models
     /// </summary>
     class VocabFilter : Filter<VocabEntity>
     {
+        #region Properties
+
         /// <summary>
         /// Gets or sets the contained kanji filter.
         /// </summary>
@@ -28,6 +31,21 @@ namespace Kanji.Interface.Models
         public string MeaningString { get; set; }
 
         /// <summary>
+        /// Gets or sets the category vocab filter.
+        /// </summary>
+        public VocabCategory Category { get; set; }
+
+        /// <summary>
+        /// Gets or sets the JLPT level vocab filter.
+        /// </summary>
+        public int JlptLevel { get; set; }
+
+        /// <summary>
+        /// Gets or sets the WaniKani level vocab filter.
+        /// </summary>
+        public int WkLevel { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating if common vocab should
         /// be listed first.
         /// </summary>
@@ -39,18 +57,30 @@ namespace Kanji.Interface.Models
         /// </summary>
         public bool IsShortReadingFirst { get; set; }
 
+        #endregion
+
+        #region Constructors
+
         public VocabFilter()
         {
             Kanji = new KanjiEntity[0] { };
             IsCommonFirst = true;
             IsShortReadingFirst = true;
+            JlptLevel = Levels.IgnoreJlptLevel;
         }
+
+        #endregion
+
+        #region Methods
 
         public override bool IsEmpty()
         {
             return !Kanji.Any()
-                && string.IsNullOrWhiteSpace(ReadingString)
-                && string.IsNullOrWhiteSpace(MeaningString);
+                   && string.IsNullOrWhiteSpace(ReadingString)
+                   && string.IsNullOrWhiteSpace(MeaningString)
+                   && Category == null
+                   && JlptLevel > Levels.MaxJlptLevel
+                   && WkLevel < Levels.MinWkLevel;
         }
 
         public override Filter<VocabEntity> Clone()
@@ -62,8 +92,13 @@ namespace Kanji.Interface.Models
                 IsShortReadingFirst = this.IsShortReadingFirst,
                 Kanji = (KanjiEntity[])this.Kanji.Clone(),
                 MeaningString = this.MeaningString,
-                ReadingString = this.ReadingString
+                ReadingString = this.ReadingString,
+                Category = this.Category,
+                JlptLevel = this.JlptLevel,
+                WkLevel = this.WkLevel
             };
         }
+
+        #endregion
     }
 }

--- a/Kanji.Interface/Properties/AssemblyInfo.cs
+++ b/Kanji.Interface/Properties/AssemblyInfo.cs
@@ -51,5 +51,5 @@ using System.Windows;
 // Vous pouvez spécifier toutes les valeurs ou indiquer les numéros de build et de révision par défaut 
 // en utilisant '*', comme indiqué ci-dessous :
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.2.0.0")]
-[assembly: AssemblyFileVersion("1.2.0.0")]
+[assembly: AssemblyVersion("1.3.0.0")]
+[assembly: AssemblyFileVersion("1.3.0.0")]

--- a/Kanji.Interface/ViewModels/KanjiViewModel.cs
+++ b/Kanji.Interface/ViewModels/KanjiViewModel.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using System.Windows.Controls;
 using System.Windows.Data;
 using GalaSoft.MvvmLight.Command;
+using Kanji.Common.Utility;
 using Kanji.Interface.Actors;
 using Kanji.Interface.Business;
 using Kanji.Interface.Models;
@@ -125,7 +126,11 @@ namespace Kanji.Interface.ViewModels
             // Create a new filter matching the vocab word selected.
             _kanjiFilter = new KanjiFilter()
             {
-                TextFilter = character.OriginalVocab.KanjiWriting
+                TextFilter = character.OriginalVocab.KanjiWriting,
+                // Ignore the levels because not only are they irrelevant,
+                // they might not even be the same for the kanji as for the vocab.
+                JlptLevel = Levels.IgnoreJlptLevel,
+                WkLevel = Levels.IgnoreWkLevel
             };
 
             // Apply the filter

--- a/Kanji.Interface/ViewModels/Partial/Common/Filters/CategoryFilterViewModel.cs
+++ b/Kanji.Interface/ViewModels/Partial/Common/Filters/CategoryFilterViewModel.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using GalaSoft.MvvmLight.Command;
+using Kanji.Database.Entities;
+using Kanji.Database.Models;
+
+namespace Kanji.Interface.ViewModels
+{
+    class CategoryFilterViewModel : FilterClauseViewModel
+    {
+        #region Properties
+		
+		public VocabCategory CategoryFilter { get; set; }
+		
+        #endregion
+		
+        #region Commands
+
+        public RelayCommand ClearCategoryFilterCommand { get; set; }
+
+        #endregion
+
+        #region Constructors
+
+        public CategoryFilterViewModel()
+        {
+			ClearCategoryFilterCommand = new RelayCommand(OnClear);
+
+	        CategoryFilter = null;
+        }
+
+	    #endregion
+
+        #region Methods
+
+        public override void ClearFilter()
+        {
+	        CategoryFilter = null;
+        }
+
+        /// <summary>
+        /// Gets the matching filter clause.
+        /// </summary>
+        public override FilterClause GetFilterClause()
+        {
+            return new SrsEntryFilterCategoryClause()
+            {
+                ID = CategoryFilter == null ? -1 : CategoryFilter.ID
+            };
+        }
+
+	    #region Command Callbacks
+
+	    private void OnClear()
+	    {
+		    CategoryFilter = null;
+			RaisePropertyChanged("CategoryFilter");
+	    }
+
+	    #endregion
+
+        #endregion
+    }
+}

--- a/Kanji.Interface/ViewModels/Partial/Common/Filters/JlptLevelFilterViewModel.cs
+++ b/Kanji.Interface/ViewModels/Partial/Common/Filters/JlptLevelFilterViewModel.cs
@@ -1,0 +1,56 @@
+using GalaSoft.MvvmLight.Command;
+using Kanji.Database.Entities;
+using Kanji.Database.Models;
+
+namespace Kanji.Interface.ViewModels
+{
+    class JlptLevelFilterViewModel : FilterClauseViewModel
+    {
+        #region Constants
+
+        /// <summary>
+        /// The value that <see cref="JlptLevel"/> has if it should be ignored.
+        /// </summary>
+        private const int filterIgnoreLevel = 6;
+
+        #endregion
+
+        #region Properties
+		
+        public int JlptLevel { get; set; }
+		
+        #endregion
+		
+        #region Constructors
+
+        public JlptLevelFilterViewModel()
+        {
+            JlptLevel = filterIgnoreLevel;
+        }
+
+        #endregion
+
+        #region Methods
+        
+        /// <summary>
+        /// Clears the filter. Should not raise a FilterChanged event.
+        /// </summary>
+        public override void ClearFilter()
+        {
+            JlptLevel = filterIgnoreLevel;
+        }
+
+        /// <summary>
+        /// Gets the matching filter clause.
+        /// </summary>
+        public override FilterClause GetFilterClause()
+        {
+            return new SrsEntryFilterJlptLevelClause()
+            {
+                Value = JlptLevel == filterIgnoreLevel ? (int?)null : JlptLevel
+            };
+        }
+        
+        #endregion
+    }
+}

--- a/Kanji.Interface/ViewModels/Partial/Common/Filters/WkLevelFilterViewModel.cs
+++ b/Kanji.Interface/ViewModels/Partial/Common/Filters/WkLevelFilterViewModel.cs
@@ -1,0 +1,54 @@
+using Kanji.Database.Models;
+
+namespace Kanji.Interface.ViewModels
+{
+    class WkLevelFilterViewModel : FilterClauseViewModel
+    {
+        #region Constants
+        
+        /// <summary>
+        /// The value that <see cref="WkLevel"/> has if it should be ignored.
+        /// </summary>
+        private const int filterIgnoreLevel = 0;
+
+        #endregion
+
+        #region Properties
+		
+        public int WkLevel { get; set; }
+		
+        #endregion
+		
+        #region Constructors
+
+        public WkLevelFilterViewModel()
+        {
+            WkLevel = filterIgnoreLevel;
+        }
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        /// Clears the filter. Should not raise a FilterChanged event.
+        /// </summary>
+        public override void ClearFilter()
+        {
+            WkLevel = filterIgnoreLevel;
+        }
+
+        /// <summary>
+        /// Gets the matching filter clause.
+        /// </summary>
+        public override FilterClause GetFilterClause()
+        {
+            return new SrsEntryFilterWkLevelClause()
+            {
+                Value = WkLevel == filterIgnoreLevel ? (int?)null : WkLevel
+            };
+        }
+        
+        #endregion
+    }
+}

--- a/Kanji.Interface/ViewModels/Partial/Kanji/KanjiFilterViewModel.cs
+++ b/Kanji.Interface/ViewModels/Partial/Kanji/KanjiFilterViewModel.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using GalaSoft.MvvmLight.Command;
 using Kanji.Common.Helpers;
+using Kanji.Common.Utility;
 using Kanji.Database.Entities;
 using Kanji.Interface.Business;
 using Kanji.Interface.Helpers;
@@ -186,6 +187,38 @@ namespace Kanji.Interface.ViewModels
                 }
             }
         }
+        
+        /// <summary>
+        /// Gets or sets the JLPT level filter applied to the vocab list.
+        /// </summary>
+        public int JlptLevel
+        {
+            get { return _filter.JlptLevel; }
+            set
+            {
+                if (_filter.JlptLevel != value)
+                {
+                    _filter.JlptLevel = value;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the WaniKani level filter applied to the vocab list.
+        /// </summary>
+        public int WkLevel
+        {
+            get { return _filter.WkLevel; }
+            set
+            {
+                if (_filter.WkLevel != value)
+                {
+                    _filter.WkLevel = value;
+                    RaisePropertyChanged();
+                }
+            }
+        }
 
         #region Commands
 
@@ -194,6 +227,15 @@ namespace Kanji.Interface.ViewModels
         public RelayCommand SendTextFilterCommand { get; set; }
         public RelayCommand SendRadicalFilterCommand { get; set; }
         public RelayCommand<RadicalSortModeEnum> SetRadicalSortModeCommand { get; set; }
+        
+        /// <summary>
+        /// Command used to validate the JLPT & WK level filters.
+        /// </summary>
+        /// <remarks>
+        /// This is a shared command named like this because the control shared with
+        /// the SRS tab wants the command to have this name.
+        /// </remarks>
+        public RelayCommand FilterChangedCommand { get; set; }
 
         #endregion
 
@@ -216,12 +258,15 @@ namespace Kanji.Interface.ViewModels
             RadicalSortMode = Kanji.Interface.Properties.Settings.Default.RadicalSortMode;
             _radicalBusiness = new RadicalBusiness();
             MainFilterMode = KanjiFilterModeEnum.Meaning;
+            JlptLevel = Levels.IgnoreJlptLevel;
+            WkLevel = Levels.IgnoreWkLevel;
 
             FilterModeChangedCommand = new RelayCommand(OnFilterModeChanged);
             SendMainFilterCommand = new RelayCommand(OnSendMainFilter);
             SendTextFilterCommand = new RelayCommand(OnSendTextFilter);
             SendRadicalFilterCommand = new RelayCommand(OnSendRadicalFilter);
             SetRadicalSortModeCommand = new RelayCommand<RadicalSortModeEnum>(OnSetRadicalSortMode);
+	        FilterChangedCommand = new RelayCommand(DoFilterChange);
 
             RadicalStore.Instance.IssueWhenLoaded(OnRadicalsLoaded);
         }
@@ -240,6 +285,8 @@ namespace Kanji.Interface.ViewModels
             MainFilterMode = KanjiFilterModeEnum.Meaning;
             Radicals.SelectedItems.Clear();
             _filter.Radicals = new FilteringRadical[0] { };
+            JlptLevel = Levels.IgnoreJlptLevel;
+            WkLevel = Levels.IgnoreWkLevel;
 
             foreach (FilteringRadical radical in Radicals)
             {
@@ -274,6 +321,8 @@ namespace Kanji.Interface.ViewModels
             RaisePropertyChanged("TextFilter");
             RaisePropertyChanged("MainFilter");
             RaisePropertyChanged("MainFilterMode");
+            RaisePropertyChanged("JlptLevel");
+            RaisePropertyChanged("WkLevel");
             ComputeRadicalAvailability();
         }
 

--- a/Kanji.Interface/ViewModels/Partial/Srs/SrsEntryFilterViewModel.cs
+++ b/Kanji.Interface/ViewModels/Partial/Srs/SrsEntryFilterViewModel.cs
@@ -26,6 +26,9 @@ namespace Kanji.Interface.ViewModels
         public SrsEntryTagsFilterViewModel TagsFilterVm { get; set; }
         public SrsEntryTypeFilterViewModel TypeFilterVm { get; set; }
         public SrsEntryLevelFilterViewModel LevelFilterVm { get; set; }
+        public CategoryFilterViewModel CategoryFilterVm { get; set; }
+        public JlptLevelFilterViewModel JlptLevelFilterVm { get; set; }
+        public WkLevelFilterViewModel WkLevelFilterVm { get; set; }
 
         #endregion
 
@@ -68,6 +71,12 @@ namespace Kanji.Interface.ViewModels
             TypeFilterVm.FilterChanged += OnFilterChanged;
             LevelFilterVm = new SrsEntryLevelFilterViewModel();
             LevelFilterVm.FilterChanged += OnFilterChanged;
+            CategoryFilterVm = new CategoryFilterViewModel();
+            CategoryFilterVm.FilterChanged += OnFilterChanged;
+            JlptLevelFilterVm = new JlptLevelFilterViewModel();
+            JlptLevelFilterVm.FilterChanged += OnFilterChanged;
+            WkLevelFilterVm = new WkLevelFilterViewModel();
+            WkLevelFilterVm.FilterChanged += OnFilterChanged;
 
             // Commands
             BrowseAllItemsCommand = new RelayCommand(OnBrowseAllItems);
@@ -88,6 +97,9 @@ namespace Kanji.Interface.ViewModels
             TagsFilterVm.ClearFilter();
             TypeFilterVm.ClearFilter();
             LevelFilterVm.ClearFilter();
+            CategoryFilterVm.ClearFilter();
+            JlptLevelFilterVm.ClearFilter();
+            WkLevelFilterVm.ClearFilter();
         }
 
         #region Command callbacks
@@ -135,7 +147,10 @@ namespace Kanji.Interface.ViewModels
                 ReadingFilterVm.GetFilterClause(),
                 TagsFilterVm.GetFilterClause(),
                 TypeFilterVm.GetFilterClause(),
-                LevelFilterVm.GetFilterClause()
+                LevelFilterVm.GetFilterClause(),
+                CategoryFilterVm.GetFilterClause(),
+                JlptLevelFilterVm.GetFilterClause(),
+                WkLevelFilterVm.GetFilterClause()
             }.Where(f => f != null)
             .ToArray();
 
@@ -163,6 +178,15 @@ namespace Kanji.Interface.ViewModels
 
             LevelFilterVm.FilterChanged -= OnFilterChanged;
             LevelFilterVm.Dispose();
+
+            CategoryFilterVm.FilterChanged -= OnFilterChanged;
+            CategoryFilterVm.Dispose();
+
+            JlptLevelFilterVm.FilterChanged -= OnFilterChanged;
+            JlptLevelFilterVm.Dispose();
+
+            WkLevelFilterVm.FilterChanged -= OnFilterChanged;
+            WkLevelFilterVm.Dispose();
 
             base.Dispose();
         }

--- a/Kanji.Interface/ViewModels/Partial/Srs/SrsEntryFilterViewModel.cs
+++ b/Kanji.Interface/ViewModels/Partial/Srs/SrsEntryFilterViewModel.cs
@@ -148,9 +148,9 @@ namespace Kanji.Interface.ViewModels
                 TagsFilterVm.GetFilterClause(),
                 TypeFilterVm.GetFilterClause(),
                 LevelFilterVm.GetFilterClause(),
-                CategoryFilterVm.GetFilterClause(),
+                /*CategoryFilterVm.GetFilterClause(),
                 JlptLevelFilterVm.GetFilterClause(),
-                WkLevelFilterVm.GetFilterClause()
+                WkLevelFilterVm.GetFilterClause()*/
             }.Where(f => f != null)
             .ToArray();
 

--- a/Kanji.Interface/ViewModels/Partial/Vocab/VocabFilterViewModel.cs
+++ b/Kanji.Interface/ViewModels/Partial/Vocab/VocabFilterViewModel.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using GalaSoft.MvvmLight.Command;
+using Kanji.Database.Entities;
 using Kanji.Interface.Models;
 
 namespace Kanji.Interface.ViewModels
@@ -17,7 +18,7 @@ namespace Kanji.Interface.ViewModels
         #endregion
 
         #region Properties
-
+        
         /// <summary>
         /// Gets or sets the reading filter applied to the vocab list.
         /// </summary>
@@ -45,6 +46,54 @@ namespace Kanji.Interface.ViewModels
                 if (_filter.MeaningString != value)
                 {
                     _filter.MeaningString = value;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the category filter applied to the vocab list.
+        /// </summary>
+        public VocabCategory CategoryFilter
+        {
+            get { return _filter.Category; }
+            set
+            {
+                if (_filter.Category != value)
+                {
+                    _filter.Category = value;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the JLPT level filter applied to the vocab list.
+        /// </summary>
+        public int JlptLevel
+        {
+            get { return _filter.JlptLevel; }
+            set
+            {
+                if (_filter.JlptLevel != value)
+                {
+                    _filter.JlptLevel = value;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the WaniKani level filter applied to the vocab list.
+        /// </summary>
+        public int WkLevel
+        {
+            get { return _filter.WkLevel; }
+            set
+            {
+                if (_filter.WkLevel != value)
+                {
+                    _filter.WkLevel = value;
                     RaisePropertyChanged();
                 }
             }
@@ -94,10 +143,29 @@ namespace Kanji.Interface.ViewModels
         public RelayCommand SendReadingFilterCommand { get; set; }
 
         /// <summary>
+        /// Command used to validate the JLPT & WK level filters.
+        /// </summary>
+        /// <remarks>
+        /// This is a shared command named like this because the control shared with
+        /// the SRS tab wants the command to have this name.
+        /// </remarks>
+        public RelayCommand FilterChangedCommand { get; set; }
+
+        /// <summary>
         /// Command used to validate the meaning filter.
         /// </summary>
         public RelayCommand SendMeaningFilterCommand { get; set; }
 
+        /// <summary>
+        /// Command used to validate the category filter.
+        /// </summary>
+        public RelayCommand SendCategoryFilterCommand { get; set; }
+        
+        /// <summary>
+        /// Command used to clear the category filter.
+        /// </summary>
+        public RelayCommand ClearCategoryFilterCommand { get; set; }
+        
         /// <summary>
         /// Command used to switch the "common first" order.
         /// </summary>
@@ -128,10 +196,13 @@ namespace Kanji.Interface.ViewModels
         /// <param name="filter">Filter to use.</param>
         public VocabFilterViewModel(VocabFilter filter)
         {
-            _filter = filter;
-
-            SendReadingFilterCommand = new RelayCommand(OnSendReadingFilter);
+	        _filter = filter;
+            
+	        FilterChangedCommand = new RelayCommand(IssueFilterChangedEvent);
+	        SendReadingFilterCommand = new RelayCommand(OnSendReadingFilter);
             SendMeaningFilterCommand = new RelayCommand(OnSendMeaningFilter);
+            SendCategoryFilterCommand = new RelayCommand(OnSendCategoryFilter);
+            ClearCategoryFilterCommand = new RelayCommand(OnClearCategoryFilter);
             SwitchCommonOrderCommand = new RelayCommand(OnSwitchCommonOrder);
             SwitchWritingLengthOrderCommand = new RelayCommand(OnSwitchWritingLengthOrder);
         }
@@ -173,6 +244,21 @@ namespace Kanji.Interface.ViewModels
 
         /// <summary>
         /// Command callback.
+        /// Issues a filter changed event.
+        /// </summary>
+        private void OnSendCategoryFilter()
+        {
+            IssueFilterChangedEvent();
+        }
+        
+        private void OnClearCategoryFilter()
+        {
+            CategoryFilter = null;
+            IssueFilterChangedEvent();
+        }
+
+        /// <summary>
+        /// Command callback.
         /// Switches the "common first" order.
         /// </summary>
         private void OnSwitchCommonOrder()
@@ -190,7 +276,7 @@ namespace Kanji.Interface.ViewModels
             IsShortReadingFirst = !IsShortReadingFirst;
             IssueFilterChangedEvent();
         }
-
+        
         #endregion
 
         #endregion

--- a/Kanji.Interface/ViewModels/Partial/Vocab/VocabListViewModel.cs
+++ b/Kanji.Interface/ViewModels/Partial/Vocab/VocabListViewModel.cs
@@ -61,6 +61,22 @@ namespace Kanji.Interface.ViewModels
         }
 
         /// <summary>
+        /// Gets or sets the category filter applied to the vocab list.
+        /// </summary>
+        public VocabCategory Category
+        {
+            get { return ((VocabFilter)_filter).Category; }
+            set
+            {
+                if (Filter.Category != value)
+                {
+                    Filter.Category = value;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        /// <summary>
         /// Private property used for convenience (get casts in VocabFilter).
         /// </summary>
         private VocabFilter Filter

--- a/Kanji.Interface/Views/EditSrsEntryWindow.xaml
+++ b/Kanji.Interface/Views/EditSrsEntryWindow.xaml
@@ -176,7 +176,7 @@
                             Mode=OneWay}"
                                  Visibility="{Binding IsEditingDate, Converter={StaticResource ValueToVisibilityConverter}, ConverterParameter=False}" />
 
-                        <xctk:DateTimePicker Grid.Column="1" Value="{Binding Entry.NextAnswerDate}" Format="Custom" FormatString="yyyy-MM-dd H:mm:ss"
+                        <xctk:DateTimePicker Grid.Column="1" Value="{Binding Entry.NextAnswerDate}" Format="FullDateTime"
                             TextAlignment="Left" Visibility="{Binding IsEditingDate, Converter={StaticResource ValueToVisibilityConverter}}"  />
                         
                         <Button Grid.Column="2" Command="{Binding ToggleDateEditCommand}" Margin="10 0 0 0" Width="70" HorizontalAlignment="Right">

--- a/Kanji.Interface/Views/EditSrsEntryWindow.xaml
+++ b/Kanji.Interface/Views/EditSrsEntryWindow.xaml
@@ -166,11 +166,11 @@
                             </TextBlock.Style>
                         </TextBlock>
                         <TextBox Grid.Column="1" Style="{StaticResource NextReviewDateLabel}"
-                                 Text="{Binding Entry.NextActiveReviewDate,
+                                 Text="{Binding Entry.NextAnswerDate,
                             Converter={StaticResource DateTimeToStringConverter},
                             ConverterParameter={x:Static converters:DateTimeToStringConversionEnum.Relative},
                             Mode=OneWay}"
-                                 ToolTip="{Binding Entry.NextActiveReviewDate,
+                                 ToolTip="{Binding Entry.NextAnswerDate,
                             Converter={StaticResource DateTimeToStringConverter},
                             ConverterParameter={x:Static converters:DateTimeToStringConversionEnum.Absolute},
                             Mode=OneWay}"

--- a/Kanji.Interface/Views/Partial/Common/Filters/CategoryFilterControl.xaml
+++ b/Kanji.Interface/Views/Partial/Common/Filters/CategoryFilterControl.xaml
@@ -1,0 +1,32 @@
+﻿<UserControl x:Class="Kanji.Interface.Controls.CategoryFilterControl"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:behaviors="clr-namespace:Kanji.Interface.Behaviors"
+             mc:Ignorable="d" 
+             d:DesignHeight="30" d:DesignWidth="500">
+    <Grid>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="Auto" />
+        </Grid.ColumnDefinitions>
+
+        <ComboBox Name="ComboBox" Margin="5,2" VerticalAlignment="Center" VerticalContentAlignment="Center"
+            FontSize="15" FontWeight="SemiBold"
+            SelectedIndex="{Binding SelectedIndex, ElementName=HiddenList}"
+            behaviors:SelectionChangedBehavior.Command="{Binding FilterChangedCommand}">
+            <ComboBox.ItemTemplate>
+                <DataTemplate>
+                    <TextBlock Text="{Binding Converter={StaticResource VocabCategoriesToStringConverter}}"
+                        VerticalAlignment="Center" FontSize="15" FontWeight="SemiBold" HorizontalAlignment="Center" />
+                </DataTemplate>
+            </ComboBox.ItemTemplate>
+        </ComboBox>
+
+        <ListBox Grid.Column="0" Name="HiddenList" Visibility="Collapsed" SelectedItem="{Binding CategoryFilter, UpdateSourceTrigger=PropertyChanged}"/>
+        <Button Style="{StaticResource MiniActionButton}" Command="{Binding ClearCategoryFilterCommand}"
+                Content="Clear" Grid.Column="1"
+                HorizontalAlignment="Left" VerticalAlignment="Center" Padding="2,0" />
+    </Grid>
+</UserControl>

--- a/Kanji.Interface/Views/Partial/Common/Filters/CategoryFilterControl.xaml.cs
+++ b/Kanji.Interface/Views/Partial/Common/Filters/CategoryFilterControl.xaml.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+using Kanji.Database.Dao;
+using Kanji.Database.Entities;
+using Kanji.Database.Models;
+using Kanji.Interface.Converters;
+using Kanji.Interface.Internationalization;
+
+namespace Kanji.Interface.Controls
+{
+    public partial class CategoryFilterControl : UserControl
+    {
+        public CategoryFilterControl()
+        {
+            InitializeComponent();
+			
+	        VocabDao dao = new VocabDao();
+	        DataContext = dao;
+
+			var converter = new VocabCategoriesToStringConverter();
+	        var allCategories = dao.GetAllCategories().ToList();
+	        var filteredCategories = allCategories.Where(cat =>
+		    {
+				// These are various types of archaic verbs.
+                // We remove these from the category list for two reasons:
+                // 1) The user would see these as individual categories;
+                // 2) None of these categories currently have any vocab words.
+				switch (cat.ShortName)
+                {
+                    case "v4k":
+                    case "v4g":
+                    case "v4s":
+                    case "v4t":
+                    case "v4n":
+                    case "v4b":
+                    case "v4m":
+                    case "v2k-k":
+                    case "v2g-k":
+                    case "v2t-k":
+                    case "v2d-k":
+                    case "v2h-k":
+                    case "v2b-k":
+                    case "v2m-k":
+                    case "v2y-k":
+                    case "v2r-k":
+                    case "v2k-s":
+                    case "v2g-s":
+                    case "v2s-s":
+                    case "v2z-s":
+                    case "v2t-s":
+                    case "v2d-s":
+                    case "v2n-s":
+                    case "v2h-s":
+                    case "v2b-s":
+                    case "v2m-s":
+                    case "v2y-s":
+                    case "v2r-s":
+                    case "v2w-s":
+                        return false;
+                }
+
+                object convertedValue = converter.Convert(cat, null, null, null);
+				return !string.IsNullOrWhiteSpace(convertedValue as string);
+		    }).ToList();
+            
+            HiddenList.ItemsSource = filteredCategories;
+	        ComboBox.ItemsSource = filteredCategories;
+        }
+    }
+}

--- a/Kanji.Interface/Views/Partial/Common/Filters/JlptLevelFilterControl.xaml
+++ b/Kanji.Interface/Views/Partial/Common/Filters/JlptLevelFilterControl.xaml
@@ -1,0 +1,36 @@
+﻿<UserControl
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:behaviors="clr-namespace:Kanji.Interface.Behaviors"
+             xmlns:converters="clr-namespace:Kanji.Interface.Converters" x:Class="Kanji.Interface.Controls.JlptLevelFilterControl"
+             mc:Ignorable="d" 
+             d:DesignHeight="30" d:DesignWidth="500">
+    <UserControl.Resources>
+        <converters:NumberToJlptLevelConverter x:Key="NumberToJlptLevelConverter"/>
+    </UserControl.Resources>
+    <Grid Height="40" VerticalAlignment="Center">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="Auto" />
+            <ColumnDefinition Width="Auto" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="Auto" />
+        </Grid.ColumnDefinitions>
+
+        <TextBlock Text="JLPT Level" Style="{StaticResource LegendText}" />
+        <TextBlock Grid.Column="1"
+                   Text="{Binding Value, Converter={StaticResource NumberToJlptLevelConverter}, ElementName=LevelSlider}"
+                   Style="{StaticResource LegendText}"
+                   Width="70"
+                   Margin="5,0"
+                   TextAlignment="Center"/>
+        <Slider x:Name="LevelSlider" Grid.Column="2" VerticalAlignment="Center"
+                Minimum="0" Maximum="6" Value="{Binding JlptLevel, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                SmallChange="1" IsDirectionReversed="True" MinWidth="50"
+                TickPlacement="BottomRight" IsSnapToTickEnabled="True" Foreground="Black" IsMoveToPointEnabled="True" />
+        <Button Style="{StaticResource MiniActionButton}" Command="{Binding FilterChangedCommand}"
+                Content="Filter" Grid.Column="3"
+                HorizontalAlignment="Center" VerticalAlignment="Center" />
+    </Grid>
+</UserControl>

--- a/Kanji.Interface/Views/Partial/Common/Filters/JlptLevelFilterControl.xaml.cs
+++ b/Kanji.Interface/Views/Partial/Common/Filters/JlptLevelFilterControl.xaml.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+using GalaSoft.MvvmLight.Command;
+using Kanji.Database.Dao;
+using Kanji.Database.Entities;
+using Kanji.Database.Models;
+using Kanji.Interface.Converters;
+using Kanji.Interface.Internationalization;
+
+namespace Kanji.Interface.Controls
+{
+    public partial class JlptLevelFilterControl : UserControl
+    {
+        public JlptLevelFilterControl()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/Kanji.Interface/Views/Partial/Common/Filters/WkLevelFilterControl.xaml
+++ b/Kanji.Interface/Views/Partial/Common/Filters/WkLevelFilterControl.xaml
@@ -1,0 +1,35 @@
+﻿<UserControl
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:behaviors="clr-namespace:Kanji.Interface.Behaviors"
+             xmlns:converters="clr-namespace:Kanji.Interface.Converters" x:Class="Kanji.Interface.Controls.WkLevelFilterControl"
+             mc:Ignorable="d" 
+             d:DesignHeight="30" d:DesignWidth="500">
+    <UserControl.Resources>
+        <converters:NumberToWkConverter x:Key="NumberToWkConverter"/>
+    </UserControl.Resources>
+    <Grid Height="40" VerticalAlignment="Center">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="Auto" />
+            <ColumnDefinition Width="Auto" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="Auto" />
+        </Grid.ColumnDefinitions>
+
+        <TextBlock Text="WaniKani Level" Style="{StaticResource LegendText}" />
+        <TextBlock Grid.Column="1"
+                   Text="{Binding Value, Converter={StaticResource NumberToWkConverter}, ElementName=LevelSlider}"
+                   Style="{StaticResource LegendText}"
+                   Width="100"
+                   Margin="5,0"
+                   TextAlignment="Center"/>
+        <Slider x:Name="LevelSlider" Grid.Column="2" VerticalAlignment="Center"
+			    Minimum="0" Maximum="61" Value="{Binding WkLevel, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" SmallChange="1" LargeChange="10"
+                TickPlacement="BottomRight" IsSnapToTickEnabled="True" Foreground="Black" IsMoveToPointEnabled="True" />
+        <Button Style="{StaticResource MiniActionButton}" Command="{Binding FilterChangedCommand}"
+                Content="Filter" Grid.Column="3"
+                HorizontalAlignment="Center" VerticalAlignment="Center" />
+    </Grid>
+</UserControl>

--- a/Kanji.Interface/Views/Partial/Common/Filters/WkLevelFilterControl.xaml.cs
+++ b/Kanji.Interface/Views/Partial/Common/Filters/WkLevelFilterControl.xaml.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+using GalaSoft.MvvmLight.Command;
+using Kanji.Database.Dao;
+using Kanji.Database.Entities;
+using Kanji.Database.Models;
+using Kanji.Interface.Converters;
+using Kanji.Interface.Internationalization;
+
+namespace Kanji.Interface.Controls
+{
+    public partial class WkLevelFilterControl : UserControl
+    {
+        public WkLevelFilterControl()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/Kanji.Interface/Views/Partial/Kanji/KanjiFilterControl.xaml
+++ b/Kanji.Interface/Views/Partial/Kanji/KanjiFilterControl.xaml
@@ -20,10 +20,10 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" /> <!-- 0. Multiline text filter -->
             <RowDefinition Height="Auto" /> <!-- 1. Meaning/reading filter -->
-            <RowDefinition Height="Auto" /> <!-- 2. Radical list label -->
-            <RowDefinition Height="*" />    <!-- 3. Radical list -->
-            <RowDefinition Height="Auto" /> <!-- 4. Radical filter -->
-            <RowDefinition Height="Auto" /> <!-- 5. JLPT/WK level filter -->
+            <RowDefinition Height="Auto" /> <!-- 2. JLPT/WK level filter -->
+            <RowDefinition Height="Auto" /> <!-- 3. Radical list label -->
+            <RowDefinition Height="*" />    <!-- 4. Radical list -->
+            <RowDefinition Height="Auto" /> <!-- 5. Radical filter -->
         </Grid.RowDefinitions>
         
         <!-- 0. Multiline text filter -->
@@ -68,15 +68,25 @@
             </ComboBox.ItemTemplate>
         </ComboBox>
 
+        <!-- JLPT/WK levels -->
+        <Grid Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="4" >
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+            <controls:WkLevelFilterControl Grid.Column="0" DataContext="{Binding}" />
+            <controls:JlptLevelFilterControl Grid.Column="1" Margin="5,0,0,0" DataContext="{Binding}" />
+        </Grid>
+
         <!-- 2. Radical list label -->
-        <TextBlock Grid.Row="2" Grid.ColumnSpan="4" Text="containing the selected radicals:" />
+        <TextBlock Grid.Row="3" Grid.ColumnSpan="4" Text="containing the selected radicals:" />
         
         <!-- 3. Radical list -->
-        <ListBox Grid.Row="3" Grid.ColumnSpan="4" Style="{StaticResource RadicalList}" Margin="0 2"
+        <ListBox Grid.Row="4" Grid.ColumnSpan="4" Style="{StaticResource RadicalList}" Margin="0 2"
             ItemsSource="{Binding Radicals}" utilities:MultiSelect.IsEnabled="True" />
         
         <!-- 4. Radical filter -->
-        <Grid Grid.Row="4" Grid.ColumnSpan="4" Margin="0 5">
+        <Grid Grid.Row="5" Grid.ColumnSpan="4" Margin="0 5">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="Auto" />
@@ -127,16 +137,6 @@
                     </Style>
                 </Button.Style>
             </Button>
-        </Grid>
-
-        <!-- JLPT/WK levels -->
-        <Grid Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="4" >
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="Auto" />
-            </Grid.ColumnDefinitions>
-            <controls:WkLevelFilterControl Grid.Column="0" DataContext="{Binding}" />
-            <controls:JlptLevelFilterControl Grid.Column="1" Margin="5,0,0,0" DataContext="{Binding}" />
         </Grid>
     </Grid>
 </UserControl>

--- a/Kanji.Interface/Views/Partial/Kanji/KanjiFilterControl.xaml
+++ b/Kanji.Interface/Views/Partial/Kanji/KanjiFilterControl.xaml
@@ -23,6 +23,7 @@
             <RowDefinition Height="Auto" /> <!-- 2. Radical list label -->
             <RowDefinition Height="*" />    <!-- 3. Radical list -->
             <RowDefinition Height="Auto" /> <!-- 4. Radical filter -->
+            <RowDefinition Height="Auto" /> <!-- 5. JLPT/WK level filter -->
         </Grid.RowDefinitions>
         
         <!-- 0. Multiline text filter -->
@@ -126,6 +127,16 @@
                     </Style>
                 </Button.Style>
             </Button>
+        </Grid>
+
+        <!-- JLPT/WK levels -->
+        <Grid Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="4" >
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+            <controls:WkLevelFilterControl Grid.Column="0" DataContext="{Binding}" />
+            <controls:JlptLevelFilterControl Grid.Column="1" Margin="5,0,0,0" DataContext="{Binding}" />
         </Grid>
     </Grid>
 </UserControl>

--- a/Kanji.Interface/Views/Partial/Srs/SelectionInfoPanel/SrsEntrySelectionActionControl.xaml
+++ b/Kanji.Interface/Views/Partial/Srs/SelectionInfoPanel/SrsEntrySelectionActionControl.xaml
@@ -213,7 +213,7 @@
                             <RadioButton x:Name="FixedDateRadio" GroupName="Timing" Content="Set all dates to this value:" IsChecked="{Binding TimingMode, Converter={StaticResource EnumBooleanConverter}, ConverterParameter=Fixed}" />
 
                             <Border Margin="15 5 0 0" BorderThickness="2 0 0 0" BorderBrush="#666666" Padding="5 0 0 0">
-                                <xctk:DateTimePicker Grid.Column="1" Value="{Binding FixedDate}" Format="Custom" FormatString="yyyy-MM-dd H:mm:ss"
+                                <xctk:DateTimePicker Grid.Column="1" Value="{Binding FixedDate}" Format="FullDateTime"
                                     TextAlignment="Left" IsEnabled="{Binding ElementName=FixedDateRadio, Mode=OneWay, Path=IsChecked}" />
                             </Border>
 

--- a/Kanji.Interface/Views/Partial/Srs/SrsEntryFilterControl.xaml
+++ b/Kanji.Interface/Views/Partial/Srs/SrsEntryFilterControl.xaml
@@ -12,6 +12,7 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
+            <!--<RowDefinition Height="*" />-->
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="*" />
@@ -23,10 +24,10 @@
         <Button Style="{StaticResource ActionButton}" Content="Browse all items" Margin="0 0 0 5"
                 Command="{Binding BrowseAllItemsCommand}" />
 
-        <Button Style="{StaticResource ActionButton}" Grid.Column="3" Content="Refresh"
+        <Button Style="{StaticResource ActionButton}" Grid.Row="0" Grid.Column="3" Content="Refresh"
                 Margin="0 0 0 5" Command="{Binding RefreshCommand}" />
 
-        <controls:SrsEntryMeaningFilterControl Grid.Row="1" DataContext="{Binding MeaningFilterVm}"
+        <controls:SrsEntryMeaningFilterControl Grid.Row="1" Grid.Column="0" DataContext="{Binding MeaningFilterVm}"
             IsInline="False" Margin="0 0 5 0" />
         <controls:SrsEntryReadingFilterControl Grid.Row="1" Grid.Column="1" DataContext="{Binding ReadingFilterVm}"
             IsInline="False" Margin="0 0 5 0" />
@@ -35,7 +36,14 @@
         <controls:SrsEntryTypeFilterControl Grid.Row="1" Grid.Column="3" DataContext="{Binding TypeFilterVm}"
             IsInline="False" />
         
-        <controls:SrsEntryLevelFilterControl Grid.Row="2" Grid.ColumnSpan="4" DataContext="{Binding LevelFilterVm}" />
+        <controls:SrsEntryLevelFilterControl Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="3" DataContext="{Binding LevelFilterVm}" />
+
+        <TextBlock Grid.Row="2" Grid.Column="3" Text="Category" Style="{StaticResource LegendText}" VerticalAlignment="Center" />
         
+        <!--<controls:SrsEntryCategoryFilterControl Grid.Row="2" Grid.Column="3" Margin="50,0,0,0" DataContext="{Binding CategoryFilterVm}" />
+
+        <controls:SrsEntryWkLevelFilterControl Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="3" DataContext="{Binding WkLevelFilterVm}" />
+        <controls:SrsEntryJlptLevelFilterControl Grid.Row="3" Grid.Column="3" DataContext="{Binding JlptLevelFilterVm}" />-->
+
     </Grid>
 </UserControl>

--- a/Kanji.Interface/Views/Partial/Vocab/VocabFilterControl.xaml
+++ b/Kanji.Interface/Views/Partial/Vocab/VocabFilterControl.xaml
@@ -8,7 +8,12 @@
              d:DesignHeight="50" d:DesignWidth="500">
 
     <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*" />
             <ColumnDefinition Width="*" />
             <ColumnDefinition Width="*" />
             <ColumnDefinition Width="Auto" />
@@ -17,7 +22,8 @@
         <!-- Reading filter -->
         <AdornerDecorator>
             <controls:CommandTextBox Text="{Binding ReadingFilter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                ValidationCommand="{Binding SendReadingFilterCommand}" IsKanaInput="True" Margin="0 0 5 0">
+                ValidationCommand="{Binding SendReadingFilterCommand}" IsKanaInput="True" Margin="0 0 5 0"
+                VerticalContentAlignment="Center">
                 <controls:WatermarkService.Watermark>
                     <TextBlock HorizontalAlignment="Center" VerticalAlignment="Center">
                         Kana reading filter
@@ -27,9 +33,10 @@
         </AdornerDecorator>
 
         <!-- Meaning filter -->
-        <AdornerDecorator Grid.Column="1">
+        <AdornerDecorator Grid.Row="0" Grid.Column="1">
             <controls:CommandTextBox Text="{Binding MeaningFilter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                ValidationCommand="{Binding SendMeaningFilterCommand}" Margin="5 0 0 0">
+                ValidationCommand="{Binding SendMeaningFilterCommand}" Margin="5 0 0 0"
+                VerticalContentAlignment="Center">
                 <controls:WatermarkService.Watermark>
                     <TextBlock HorizontalAlignment="Center" VerticalAlignment="Center">
                         Meaning filter
@@ -38,8 +45,16 @@
             </controls:CommandTextBox>
         </AdornerDecorator>
         
+        <!-- Category filter -->
+        <AdornerDecorator Grid.Row="0" Grid.Column="2" Margin="5,0,5,0">
+            <Grid>
+                <TextBlock Text="Category Filter" Style="{StaticResource LegendText}" />
+                <controls:CategoryFilterControl Margin="80,0,0,0" DataContext="{Binding}" />
+            </Grid>
+        </AdornerDecorator>
+        
         <!-- Filter buttons -->
-        <StackPanel Orientation="Horizontal" Grid.Column="2" Margin="5 0 0 0">
+        <StackPanel Orientation="Horizontal" Grid.Row="0" Grid.Column="3" Margin="5 0 0 0">
             <Button Content="pack://application:,,,/Data/UI/SortFrequencyIcon.png"
                 Command="{Binding SwitchCommonOrderCommand}">
                 <Button.Style>
@@ -99,5 +114,10 @@
                 </Button.Style>
             </Button>
         </StackPanel>
+
+        <!-- JLPT/WK levels -->
+        <controls:WkLevelFilterControl Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" DataContext="{Binding}" />
+        <controls:JlptLevelFilterControl Grid.Row="1" Grid.Column="2" Grid.ColumnSpan="2" Margin="5,0,0,0" DataContext="{Binding}" />
+
     </Grid>
 </UserControl>

--- a/Kanji.sln
+++ b/Kanji.sln
@@ -1,14 +1,9 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
+# Visual Studio 14
+VisualStudioVersion = 14.0.25123.0
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Kanji.Interface", "Kanji.Interface\Kanji.Interface.csproj", "{ED8C261A-4BC5-4A25-914C-440FEE3534D3}"
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{FE599DC1-DEE5-47DE-BD28-FE4179322215}"
-	ProjectSection(SolutionItems) = preProject
-		.nuget\NuGet.Config = .nuget\NuGet.Config
-		.nuget\NuGet.exe = .nuget\NuGet.exe
-		.nuget\NuGet.targets = .nuget\NuGet.targets
-	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Kanji.DatabaseMaker", "Kanji.DatabaseMaker\Kanji.DatabaseMaker.csproj", "{11D42FAB-4420-488E-A6B2-2EC3F93B6C96}"
 EndProject


### PR DESCRIPTION
For both kanji and vocab, added filtering by JLPT and WaniKani level.
For vocab only, added filtering by category (e.g. na-adjective or sports term).

Also, I (slightly) optimized vocab/kanji/radical searching by using String.Format(...) or StringBuilder instead of repeated string concatenation.

@Doublevil You mentioned in the Readme that you got the WK level data from WaniKani, but how exactly did you get it? I'm asking because (as noted in the commit message) some things that (according to the current database) are not taught on WK are actually taught there. So I'm guessing Houhou is using obsolete data here.