### PR TITLE
Keyboard shortcuts + Wrap Up

### DIFF
--- a/Kanji.Common/Helpers/KanaHelper.cs
+++ b/Kanji.Common/Helpers/KanaHelper.cs
@@ -739,6 +739,8 @@ namespace Kanji.Common.Helpers
             romaji = romaji.Replace("dye", "ぢぇ");
             romaji = romaji.Replace("DYO", "ヂョ");
             romaji = romaji.Replace("dyo", "ぢょ");
+            romaji = romaji.Replace("XTU", "ッ");
+            romaji = romaji.Replace("xtu", "っ");
             romaji = romaji.Replace("XWA", "ヮ");
             romaji = romaji.Replace("xwa", "ゎ");
             romaji = romaji.Replace("XKA", "ヵ");

--- a/Kanji.Database/Dao/KanjiDao.cs
+++ b/Kanji.Database/Dao/KanjiDao.cs
@@ -424,21 +424,21 @@ namespace Kanji.Database.Dao
                 int idParamIndex = 0;
 
                 // Start with the request for all mandatory radicals.
-	            bool hasMandatoryRadicals = mandatoryRadicals.Any();
-	            if (hasMandatoryRadicals)
+                bool hasMandatoryRadicals = mandatoryRadicals.Any();
+                if (hasMandatoryRadicals)
                 {
                     sqlRadicalFilter.Append("(SELECT COUNT(*) FROM (");
-	                for (int i = 0; i < mandatoryRadicals.Length; i++)
-	                {
-		                RadicalEntity radical = mandatoryRadicals[i];
-		                sqlRadicalFilter.AppendFormat("SELECT @rid{0} ", idParamIndex);
-		                if (i < mandatoryRadicals.Length - 1)
-		                {
-			                sqlRadicalFilter.Append("UNION ");
-		                }
-		                parameters.Add(new DaoParameter("@rid" + idParamIndex++, radical.ID));
-	                }
-	                sqlRadicalFilter.AppendFormat(
+                    for (int i = 0; i < mandatoryRadicals.Length; i++)
+                    {
+                        RadicalEntity radical = mandatoryRadicals[i];
+                        sqlRadicalFilter.AppendFormat("SELECT @rid{0} ", idParamIndex);
+                        if (i < mandatoryRadicals.Length - 1)
+                        {
+                            sqlRadicalFilter.Append("UNION ");
+                        }
+                        parameters.Add(new DaoParameter("@rid" + idParamIndex++, radical.ID));
+                    }
+                    sqlRadicalFilter.AppendFormat(
                         "INTERSECT SELECT kr.{0} FROM {1} kr WHERE kr.{2}=k.{3}))=@radicalsCount ",
                         SqlHelper.Field_Kanji_Radical_RadicalId,
                         SqlHelper.Table_Kanji_Radical,
@@ -448,29 +448,29 @@ namespace Kanji.Database.Dao
                 }
 
                 // Now build the requests for the option groups.
-	            for (int i = 0; i < optionGroups.Length; i++)
-	            {
-		            RadicalGroup optionGroup = optionGroups[i];
-		            if (hasMandatoryRadicals || i > 0)
-			            sqlRadicalFilter.Append("AND ");
+                for (int i = 0; i < optionGroups.Length; i++)
+                {
+                    RadicalGroup optionGroup = optionGroups[i];
+                    if (hasMandatoryRadicals || i > 0)
+                        sqlRadicalFilter.Append("AND ");
 
-		            sqlRadicalFilter.Append("(SELECT COUNT(*) FROM (");
-		            foreach (RadicalEntity radical in optionGroup.Radicals)
-		            {
-			            sqlRadicalFilter.AppendFormat("SELECT @rid{0} ", idParamIndex);
-			            if (optionGroup.Radicals.Last() != radical)
-			            {
-				            sqlRadicalFilter.Append("UNION ");
-			            }
-			            parameters.Add(new DaoParameter("@rid" + idParamIndex++, radical.ID));
-		            }
-		            sqlRadicalFilter.AppendFormat(
-			            "INTERSECT SELECT kr.{0} FROM {1} kr WHERE kr.{2}=k.{3}))>=1 ",
-			            SqlHelper.Field_Kanji_Radical_RadicalId,
-			            SqlHelper.Table_Kanji_Radical,
-			            SqlHelper.Field_Kanji_Radical_KanjiId,
-			            SqlHelper.Field_Kanji_Id);
-	            }
+                    sqlRadicalFilter.Append("(SELECT COUNT(*) FROM (");
+                    foreach (RadicalEntity radical in optionGroup.Radicals)
+                    {
+                        sqlRadicalFilter.AppendFormat("SELECT @rid{0} ", idParamIndex);
+                        if (optionGroup.Radicals.Last() != radical)
+                        {
+                            sqlRadicalFilter.Append("UNION ");
+                        }
+                        parameters.Add(new DaoParameter("@rid" + idParamIndex++, radical.ID));
+                    }
+                    sqlRadicalFilter.AppendFormat(
+                        "INTERSECT SELECT kr.{0} FROM {1} kr WHERE kr.{2}=k.{3}))>=1 ",
+                        SqlHelper.Field_Kanji_Radical_RadicalId,
+                        SqlHelper.Table_Kanji_Radical,
+                        SqlHelper.Field_Kanji_Radical_KanjiId,
+                        SqlHelper.Field_Kanji_Id);
+                }
             }
 
             string sqlMeaningFilter = string.Empty;

--- a/Kanji.Database/Dao/KanjiDao.cs
+++ b/Kanji.Database/Dao/KanjiDao.cs
@@ -448,28 +448,29 @@ namespace Kanji.Database.Dao
                 }
 
                 // Now build the requests for the option groups.
-                foreach (RadicalGroup optionGroup in optionGroups)
-                {
-					if (hasMandatoryRadicals)
-						sqlRadicalFilter.Append("AND ");
+	            for (int i = 0; i < optionGroups.Length; i++)
+	            {
+		            RadicalGroup optionGroup = optionGroups[i];
+		            if (hasMandatoryRadicals || i > 0)
+			            sqlRadicalFilter.Append("AND ");
 
-                    sqlRadicalFilter.Append("(SELECT COUNT(*) FROM (");
-                    foreach (RadicalEntity radical in optionGroup.Radicals)
-                    {
-                        sqlRadicalFilter.AppendFormat("SELECT @rid{0} ", idParamIndex);
-                        if (optionGroup.Radicals.Last() != radical)
-                        {
-                            sqlRadicalFilter.Append("UNION ");
-                        }
-                        parameters.Add(new DaoParameter("@rid" + idParamIndex++, radical.ID));
-                    }
-                    sqlRadicalFilter.AppendFormat(
-                        "INTERSECT SELECT kr.{0} FROM {1} kr WHERE kr.{2}=k.{3}))>=1 ",
-                        SqlHelper.Field_Kanji_Radical_RadicalId,
-                        SqlHelper.Table_Kanji_Radical,
-                        SqlHelper.Field_Kanji_Radical_KanjiId,
-                        SqlHelper.Field_Kanji_Id);
-                }
+		            sqlRadicalFilter.Append("(SELECT COUNT(*) FROM (");
+		            foreach (RadicalEntity radical in optionGroup.Radicals)
+		            {
+			            sqlRadicalFilter.AppendFormat("SELECT @rid{0} ", idParamIndex);
+			            if (optionGroup.Radicals.Last() != radical)
+			            {
+				            sqlRadicalFilter.Append("UNION ");
+			            }
+			            parameters.Add(new DaoParameter("@rid" + idParamIndex++, radical.ID));
+		            }
+		            sqlRadicalFilter.AppendFormat(
+			            "INTERSECT SELECT kr.{0} FROM {1} kr WHERE kr.{2}=k.{3}))>=1 ",
+			            SqlHelper.Field_Kanji_Radical_RadicalId,
+			            SqlHelper.Table_Kanji_Radical,
+			            SqlHelper.Field_Kanji_Radical_KanjiId,
+			            SqlHelper.Field_Kanji_Id);
+	            }
             }
 
             string sqlMeaningFilter = string.Empty;

--- a/Kanji.Database/Dao/VocabDao.cs
+++ b/Kanji.Database/Dao/VocabDao.cs
@@ -640,6 +640,8 @@ namespace Kanji.Database.Dao
 				 * 
 				 * This does mean that this query must be changed if vocab items ever
 				 * get a category attached to them.
+				 * 
+				 * Actually, scratch that. Ateji DO have a category attached to the vocab themselves.
 				 */
 
 	            string subQuery = string.Format("(SELECT m.{0} FROM {1} m WHERE m.{2}=@cat)",

--- a/Kanji.Database/Entities/KanjiDatabase/VocabCategory.cs
+++ b/Kanji.Database/Entities/KanjiDatabase/VocabCategory.cs
@@ -34,5 +34,13 @@ namespace Kanji.Database.Entities
         {
             return Dao.DaoConnectionEnum.KanjiDatabase;
         }
+
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            // Used for selecting items by typing the first letter.
+            // TODO: This should use the same value as VocabCategoriesToStringConverter.
+            return Label;
+        }
     }
 }

--- a/Kanji.Interface/Actors/NavigationActor.cs
+++ b/Kanji.Interface/Actors/NavigationActor.cs
@@ -111,6 +111,9 @@ namespace Kanji.Interface.Actors
         {
             lock (_mainWindowLock)
             {
+                if (CurrentPage == page)
+                    return;
+
                 RequireMainWindow();
                 CurrentPage = page;
             }

--- a/Kanji.Interface/Converters/KanjiToReadingListConverter.cs
+++ b/Kanji.Interface/Converters/KanjiToReadingListConverter.cs
@@ -38,10 +38,10 @@ namespace Kanji.Interface.Converters
                 results.AddRange(GetReadingList(kanji.DbKanji.KunYomi, Properties.Settings.Default.KunYomiReadingType));
             }
 
-            if (!string.IsNullOrWhiteSpace(kanji.DbKanji.Nanori) && Kanji.Interface.Properties.Settings.Default.ShowNanori)
+            if (!string.IsNullOrWhiteSpace(kanji.DbKanji.Nanori) && Properties.Settings.Default.ShowNanori)
             {
                 results.Add(new KanjiReadingLabel() { Label = "Nanori" });
-                results.AddRange(GetReadingList(kanji.DbKanji.KunYomi, Properties.Settings.Default.NanoriReadingType));
+                results.AddRange(GetReadingList(kanji.DbKanji.Nanori, Properties.Settings.Default.NanoriReadingType));
             }
 
             return results;

--- a/Kanji.Interface/Data/Resources/HomePageChangelog.xml
+++ b/Kanji.Interface/Data/Resources/HomePageChangelog.xml
@@ -2,6 +2,15 @@
 <ArrayOfChangelogEntry xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <ChangelogEntry>
     <Version>1.3</Version>
+    <Title>Wrap Up</Title>
+    <Description>While doing reviews, there is now a 'Wrap up' button that ends the review session withouth a loss of data.
+This means that all kanji and vocab of which the reading question has appeared in the session will get their meaning question soon and vice versa, but no new kanji and vocab will appear in this session.
+(Note that since review items are scheduled in batches, items in the current batch of which neither the meaning nor reading has appeared will still appear in this session.)
+
+This helps when you're in a hurry, or when you have 300 reviews and don't want to do all of them at once.</Description>
+  </ChangelogEntry>
+   <ChangelogEntry>
+    <Version>1.3</Version>
     <Title>Shortcuts!</Title>
     <Description>Many tasks can now be performed with the keyboard, no mouse needed! Check the help page for more information (under 'Efficiency tips...').</Description>
   </ChangelogEntry>

--- a/Kanji.Interface/Data/Resources/HomePageChangelog.xml
+++ b/Kanji.Interface/Data/Resources/HomePageChangelog.xml
@@ -7,7 +7,9 @@
 This means that all kanji and vocab of which the reading question has appeared in the session will get their meaning question soon and vice versa, but no new kanji and vocab will appear in this session.
 (Note that since review items are scheduled in batches, items in the current batch of which neither the meaning nor reading has appeared will still appear in this session.)
 
-This helps when you're in a hurry, or when you have 300 reviews and don't want to do all of them at once.</Description>
+This helps when you're in a hurry, or when you have 300 reviews and don't want to do all of them at once.
+
+Note: The old behaviour of exiting the review immediately is still available through the little 'X' button next to it.</Description>
   </ChangelogEntry>
    <ChangelogEntry>
     <Version>1.3</Version>
@@ -20,7 +22,7 @@ This helps when you're in a hurry, or when you have 300 reviews and don't want t
     <Description>You can now filter vocabulary words and kanji by the level at which they are taught on the Kanji learning website WaniKani and the JLPT level at which they are used.
 
 Moreover, vocabulary words can now be filtered by their categories (such as mathematical terms and computer-related terms).
-Note that a lot of categories currently exist, but many of them are not used.</Description>
+Note that some categories actually do not contain any words.</Description>
   </ChangelogEntry>
   <ChangelogEntry>
     <Version>1.2</Version>

--- a/Kanji.Interface/Data/Resources/HomePageChangelog.xml
+++ b/Kanji.Interface/Data/Resources/HomePageChangelog.xml
@@ -3,7 +3,7 @@
   <ChangelogEntry>
     <Version>1.3</Version>
     <Title>Wrap Up</Title>
-    <Description>While doing reviews, there is now a 'Wrap up' button that ends the review session withouth a loss of data.
+    <Description>While doing reviews, there is now a 'Wrap up' button that ends the review session without a loss of data.
 This means that all kanji and vocab of which the reading question has appeared in the session will get their meaning question soon and vice versa, but no new kanji and vocab will appear in this session.
 (Note that since review items are scheduled in batches, items in the current batch of which neither the meaning nor reading has appeared will still appear in this session.)
 
@@ -21,8 +21,7 @@ Note: The old behaviour of exiting the review immediately is still available thr
     <Title>Filter vocab/kanji by JLPT/WK level</Title>
     <Description>You can now filter vocabulary words and kanji by the level at which they are taught on the Kanji learning website WaniKani and the JLPT level at which they are used.
 
-Moreover, vocabulary words can now be filtered by their categories (such as mathematical terms and computer-related terms).
-Note that some categories actually do not contain any words.</Description>
+Moreover, vocabulary words can now be filtered by their categories (such as mathematical terms and computer-related terms).</Description>
   </ChangelogEntry>
   <ChangelogEntry>
     <Version>1.2</Version>

--- a/Kanji.Interface/Data/Resources/HomePageChangelog.xml
+++ b/Kanji.Interface/Data/Resources/HomePageChangelog.xml
@@ -2,6 +2,11 @@
 <ArrayOfChangelogEntry xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <ChangelogEntry>
     <Version>1.3</Version>
+    <Title>Shortcuts!</Title>
+    <Description>Many tasks can now be performed with the keyboard, no mouse needed! Check the help page for more information (under 'Efficiency tips...').</Description>
+  </ChangelogEntry>
+  <ChangelogEntry>
+    <Version>1.3</Version>
     <Title>Filter vocab/kanji by JLPT/WK level</Title>
     <Description>You can now filter vocabulary words and kanji by the level at which they are taught on the Kanji learning website WaniKani and the JLPT level at which they are used.
 

--- a/Kanji.Interface/Data/Resources/HomePageFutureChanges.xml
+++ b/Kanji.Interface/Data/Resources/HomePageFutureChanges.xml
@@ -6,11 +6,6 @@
     <Description>I'm not satisfied with the speed of vocab search.</Description>
   </ChangelogEntry>
   <ChangelogEntry>
-    <Version>Soon?</Version>
-    <Title>Keyboard shortcuts</Title>
-    <Description>They should have been there already. There will be shortcuts to navigate to each tab, to start searching for a new Kanji, for vocab, SRS, etc.</Description>
-  </ChangelogEntry>
-  <ChangelogEntry>
     <Version>Maybe later</Version>
     <Title>Web synchronization</Title>
     <Description>Synchronize your SRS items with an account on the website.</Description>

--- a/Kanji.Interface/Data/Resources/HomePageHelp.xml
+++ b/Kanji.Interface/Data/Resources/HomePageHelp.xml
@@ -684,6 +684,12 @@ If you don't like the names of your Radicals, why not change them? See the "Radi
         <Title>Filter fields clear shortcut</Title>
         <Content>Most of the filter fields have the ability to clear when you press the mouse middle button while hovering the field. You can use this "shortcut" to quickly start a new filter search.</Content>
       </HelpInfo>
+	  <HelpInfo>
+        <Title>Other shortcuts</Title>
+        <Content>You can press any of the numbered keys on your keyboard (either at the top or on the numpad) while holding the Control key to jump to the tab with that number. For example, Control+1 jumps to the home page and Control+3 to the kanji page.
+
+Aside from that, many buttons, text fields and other UI elements have shortcut keys that you can press instead of clicking them with the mouse. Hover your mouse over an element to learn if it has a shortcut.</Content>
+      </HelpInfo>
     </Content>
   </HelpCategory>
 </ArrayOfHelpCategory>

--- a/Kanji.Interface/MainWindow.xaml
+++ b/Kanji.Interface/MainWindow.xaml
@@ -5,9 +5,10 @@
         xmlns:views="clr-namespace:Kanji.Interface.Views"
         xmlns:actors="clr-namespace:Kanji.Interface.Actors"
         xmlns:models="clr-namespace:Kanji.Interface.Models"
-        Title="Houhou" Height="600" Width="1000">
+        Title="Houhou" Height="600" Width="1000" KeyDown="OnKeyDown">
+
     <Grid>
-        <views:HomePage>
+        <views:HomePage x:Name="HomePage">
             <views:HomePage.Style>
                 <Style TargetType="UserControl">
                     <Style.Triggers>

--- a/Kanji.Interface/MainWindow.xaml.cs
+++ b/Kanji.Interface/MainWindow.xaml.cs
@@ -15,17 +15,24 @@ using Kanji.Common.Helpers;
 using Kanji.Interface.Actors;
 using Kanji.Interface.Business;
 using Kanji.Interface.Models;
+using Kanji.Interface.ViewModels;
 using Kanji.Interface.Views;
 
 namespace Kanji.Interface
 {
     public partial class MainWindow : Window
     {
+        #region Constructors
+
         public MainWindow()
         {
             // Initialize the components.
             InitializeComponent();
         }
+
+        #endregion
+
+        #region Methods
 
         protected override void OnClosed(EventArgs e)
         {
@@ -33,5 +40,53 @@ namespace Kanji.Interface
             Kanji.Interface.Properties.Settings.Default.Save();
             NavigationActor.Instance.SendMainWindowCloseEvent();
         }
+
+        /// <summary>
+        /// Since a <see cref="GalaSoft.MvvmLight.Command.RelayCommand"/> does not accept keyboard shortcuts,
+        /// we have to manually invoke the commands on a keyboard event.
+        /// </summary>
+        private void OnKeyDown(object sender, KeyEventArgs e)
+        {
+            KeyboardDevice keyboardDevice = e.KeyboardDevice;
+
+            if (keyboardDevice.IsKeyDown(Key.LeftCtrl) || keyboardDevice.IsKeyDown(Key.RightCtrl))
+            {
+                // Use CTRL+Numbers (starting at 1) to navigate to the respective tabs.
+
+                NavigationPageEnum? navigationTarget = null;
+
+                switch (e.Key)
+                {
+                    case Key.D1:
+                    case Key.NumPad1:
+                        navigationTarget = NavigationPageEnum.Home;
+                        break;
+                    case Key.D2:
+                    case Key.NumPad2:
+                        navigationTarget = NavigationPageEnum.Srs;
+                        break;
+                    case Key.D3:
+                    case Key.NumPad3:
+                        navigationTarget = NavigationPageEnum.Kanji;
+                        break;
+                    case Key.D4:
+                    case Key.NumPad4:
+                        navigationTarget = NavigationPageEnum.Vocab;
+                        break;
+                    case Key.D5:
+                    case Key.NumPad5:
+                        navigationTarget = NavigationPageEnum.Settings;
+                        break;
+                }
+
+                if (navigationTarget.HasValue)
+                {
+                    NavigableViewModel navModel = (NavigableViewModel)HomePage.DataContext;
+                    navModel.NavigateCommand.Execute(navigationTarget.Value);
+                }
+            }
+        }
+
+        #endregion
     }
 }

--- a/Kanji.Interface/MainWindow.xaml.cs
+++ b/Kanji.Interface/MainWindow.xaml.cs
@@ -83,6 +83,7 @@ namespace Kanji.Interface
                 {
                     NavigableViewModel navModel = (NavigableViewModel)HomePage.DataContext;
                     navModel.NavigateCommand.Execute(navigationTarget.Value);
+                    e.Handled = true;
                 }
             }
         }

--- a/Kanji.Interface/ViewModels/KanjiViewModel.cs
+++ b/Kanji.Interface/ViewModels/KanjiViewModel.cs
@@ -73,6 +73,11 @@ namespace Kanji.Interface.ViewModels
         public RelayCommand ClearFilterCommand { get; set; }
 
         public RelayCommand NavigateBackCommand { get; set; }
+        
+        /// <summary>
+        /// Command used apply the filter.
+        /// </summary>
+        public RelayCommand ApplyFilterCommand { get; set; }
 
         #endregion
 
@@ -94,6 +99,7 @@ namespace Kanji.Interface.ViewModels
 
             ClearSelectedKanjiCommand = new RelayCommand(OnClearSelectedKanji);
             ClearFilterCommand = new RelayCommand(OnClearFilter);
+	        ApplyFilterCommand = new RelayCommand(OnApplyFilter);
             NavigateBackCommand = new RelayCommand(OnNavigateBack);
 
             _navigationHistory = new FixedSizeStack<KanjiNavigationEntry>(
@@ -245,6 +251,13 @@ namespace Kanji.Interface.ViewModels
         {
             SetKanjiDetailsVm(null);
             KanjiListVm.ClearSelection();
+
+            int navigationHistorySize = _navigationHistory.Count;
+            for (int i = 0; i < navigationHistorySize; i++)
+            {
+                _navigationHistory.Pop();
+            }
+            RaisePropertyChanged("CanNavigateBack");
         }
 
         /// <summary>
@@ -254,6 +267,15 @@ namespace Kanji.Interface.ViewModels
         private void OnClearFilter()
         {
             KanjiFilterVm.ClearFilter();
+        }
+
+        /// <summary>
+        /// Command callback.
+        /// Applies the kanji filter.
+        /// </summary>
+        private void OnApplyFilter()
+        {
+            KanjiFilterVm.ApplyFilter();
         }
 
         /// <summary>

--- a/Kanji.Interface/ViewModels/KanjiViewModel.cs
+++ b/Kanji.Interface/ViewModels/KanjiViewModel.cs
@@ -66,6 +66,11 @@ namespace Kanji.Interface.ViewModels
         /// </summary>
         public bool CanNavigateBack { get { return _navigationHistory.Count > 0; } }
 
+        /// <summary>
+        /// Gets a boolean indicating whether the 'apply filter' button should be shown.
+        /// </summary>
+        public bool CanApplyFilter { get { return _kanjiDetailsVm == null; } }
+
         #region Commands
 
         public RelayCommand ClearSelectedKanjiCommand { get; set; }
@@ -193,6 +198,7 @@ namespace Kanji.Interface.ViewModels
                 {
                     _kanjiDetailsVm.KanjiNavigated += OnKanjiNavigated;
                 }
+                RaisePropertyChanged("CanApplyFilter");
             }
         }
 

--- a/Kanji.Interface/ViewModels/Partial/Common/Filters/CategoryFilterViewModel.cs
+++ b/Kanji.Interface/ViewModels/Partial/Common/Filters/CategoryFilterViewModel.cs
@@ -1,16 +1,56 @@
-﻿using System;
+﻿using System.Collections.Generic;
+using System.Linq;
 using GalaSoft.MvvmLight.Command;
+using Kanji.Database.Dao;
 using Kanji.Database.Entities;
 using Kanji.Database.Models;
+using Kanji.Interface.Converters;
 
 namespace Kanji.Interface.ViewModels
 {
     class CategoryFilterViewModel : FilterClauseViewModel
     {
+        #region Fields
+
+        private static readonly VocabCategory[] categories;
+
+        private int _selectedCategoryIndex;
+
+        #endregion
+
         #region Properties
-		
-		public VocabCategory CategoryFilter { get; set; }
-		
+
+        public VocabCategory CategoryFilter
+        {
+            get { return SelectedCategoryIndex < 0 ? null : categories[SelectedCategoryIndex]; }
+            set { SelectedCategoryIndex = System.Array.IndexOf(categories, value); }
+        }
+
+        /// <summary>
+        /// Gets the list of all supported <see cref="VocabCategory"/> objects.
+        /// </summary>
+        public VocabCategory[] Categories
+        {
+            get { return categories; }
+        }
+
+        /// <summary>
+        /// Gets or sets index of the selected category.
+        /// </summary>
+        public int SelectedCategoryIndex
+        {
+            get { return _selectedCategoryIndex; }
+            set
+            {
+                if (_selectedCategoryIndex != value)
+                {
+                    _selectedCategoryIndex = value;
+                    RaisePropertyChanged();
+			        RaisePropertyChanged("CategoryFilter");
+                }
+            }
+        }
+
         #endregion
 		
         #region Commands
@@ -26,9 +66,61 @@ namespace Kanji.Interface.ViewModels
 			ClearCategoryFilterCommand = new RelayCommand(OnClear);
 
 	        CategoryFilter = null;
+            _selectedCategoryIndex = -1;
         }
 
-	    #endregion
+        static CategoryFilterViewModel()
+        {
+            var converter = new VocabCategoriesToStringConverter();
+            VocabDao dao = new VocabDao();
+            var allCategories = dao.GetAllCategories().OrderBy(cat => cat.Label);
+            categories = allCategories.Where(
+                cat =>
+                {
+                    // These are various types of archaic verbs.
+                    // We remove these from the category list for two reasons:
+                    // 1) The user would see these as individual categories;
+                    // 2) None of these categories currently have any vocab words.
+                    switch (cat.ShortName)
+                    {
+                        case "v4k":
+                        case "v4g":
+                        case "v4s":
+                        case "v4t":
+                        case "v4n":
+                        case "v4b":
+                        case "v4m":
+                        case "v2k-k":
+                        case "v2g-k":
+                        case "v2t-k":
+                        case "v2d-k":
+                        case "v2h-k":
+                        case "v2b-k":
+                        case "v2m-k":
+                        case "v2y-k":
+                        case "v2r-k":
+                        case "v2k-s":
+                        case "v2g-s":
+                        case "v2s-s":
+                        case "v2z-s":
+                        case "v2t-s":
+                        case "v2d-s":
+                        case "v2n-s":
+                        case "v2h-s":
+                        case "v2b-s":
+                        case "v2m-s":
+                        case "v2y-s":
+                        case "v2r-s":
+                        case "v2w-s":
+                            return false;
+                    }
+
+                    object convertedValue = converter.Convert(cat, null, null, null);
+                    return !string.IsNullOrWhiteSpace(convertedValue as string);
+                }).ToArray();
+        }
+
+        #endregion
 
         #region Methods
 

--- a/Kanji.Interface/ViewModels/Partial/Common/NavigableViewModel.cs
+++ b/Kanji.Interface/ViewModels/Partial/Common/NavigableViewModel.cs
@@ -49,10 +49,7 @@ namespace Kanji.Interface.ViewModels
         /// <param name="destinationPage">Destination page.</param>
         protected void Navigate(NavigationPageEnum destinationPage)
         {
-            if (destinationPage != CurrentPage)
-            {
-                NavigationActor.Instance.Navigate(destinationPage);
-            }
+            NavigationActor.Instance.Navigate(destinationPage);
         }
 
         #endregion

--- a/Kanji.Interface/ViewModels/Partial/Kanji/KanjiDetailsViewModel.cs
+++ b/Kanji.Interface/ViewModels/Partial/Kanji/KanjiDetailsViewModel.cs
@@ -454,7 +454,14 @@ namespace Kanji.Interface.ViewModels
         /// <param name="reading">Reading to use as a filter.</param>
         private void OnFilterReading(string reading)
         {
-            VocabFilterVm.ReadingFilter = reading.Replace("ー", string.Empty).Replace(".", string.Empty);
+            // This command is not fired by typing, but rather from events like
+            // clicking on a reading on the kanji page.
+            // In those events, we *do* want to automatically re-apply the filter.
+            string newReading = reading.Replace("ー", string.Empty).Replace(".", string.Empty);
+            if (VocabFilterVm.ReadingFilter == newReading)
+                return;
+            VocabFilterVm.ReadingFilter = newReading;
+            VocabListVm.ReapplyFilter();
         }
 
         /// <summary>
@@ -576,8 +583,8 @@ namespace Kanji.Interface.ViewModels
         /// </summary>
         private void OnVocabPropertyChanged(object sender, PropertyChangedEventArgs e)
         {
-            if (e.PropertyName == "ReadingFilter")
-                VocabListVm.ReapplyFilter();
+            //if (e.PropertyName == "ReadingFilter")
+            //    VocabListVm.ReapplyFilter();
         }
 
         /// <summary>

--- a/Kanji.Interface/ViewModels/Partial/Kanji/KanjiDetailsViewModel.cs
+++ b/Kanji.Interface/ViewModels/Partial/Kanji/KanjiDetailsViewModel.cs
@@ -257,6 +257,7 @@ namespace Kanji.Interface.ViewModels
             VocabListVm.KanjiNavigated += OnKanjiNavigated;
             VocabFilterVm = new VocabFilterViewModel(filter);
             VocabFilterVm.FilterChanged += OnVocabFilterChanged;
+            VocabFilterVm.PropertyChanged += OnVocabPropertyChanged;
 
             ToggleDetailsCommand = new RelayCommand(OnToggleDetails);
             AddToSrsCommand = new RelayCommand(OnAddToSrs);
@@ -566,6 +567,17 @@ namespace Kanji.Interface.ViewModels
         private void OnVocabFilterChanged(object sender, EventArgs e)
         {
             VocabListVm.ReapplyFilter();
+        }
+
+        /// <summary>
+        /// Event callback.
+        /// Called when a vocab property changes.
+        /// Refreshes the vocab list.
+        /// </summary>
+        private void OnVocabPropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == "ReadingFilter")
+                VocabListVm.ReapplyFilter();
         }
 
         /// <summary>

--- a/Kanji.Interface/ViewModels/Partial/Kanji/KanjiDetailsViewModel.cs
+++ b/Kanji.Interface/ViewModels/Partial/Kanji/KanjiDetailsViewModel.cs
@@ -54,6 +54,11 @@ namespace Kanji.Interface.ViewModels
         #region Properties
 
         /// <summary>
+        /// Gets the category filter view model.
+        /// </summary>
+        public CategoryFilterViewModel CategoryFilterVm { get; private set; }
+
+        /// <summary>
         /// Gets the vocab list view model.
         /// </summary>
         public VocabListViewModel VocabListVm { get; private set; }
@@ -244,6 +249,9 @@ namespace Kanji.Interface.ViewModels
 
             VocabFilter filter = new VocabFilter() {
                 Kanji = new KanjiEntity[] { _kanjiEntity.DbKanji } };
+
+            CategoryFilterVm = new CategoryFilterViewModel();
+            CategoryFilterVm.PropertyChanged += OnCategoryChanged;
 
             VocabListVm = new VocabListViewModel(filter);
             VocabListVm.KanjiNavigated += OnKanjiNavigated;
@@ -537,6 +545,17 @@ namespace Kanji.Interface.ViewModels
                 // If different, forward the event.
                 KanjiNavigated(sender, e);
             }
+        }
+        
+        /// <summary>
+        /// Event callback.
+        /// Called when the vocab category changes.
+        /// Refreshes the vocab list.
+        /// </summary>
+        private void OnCategoryChanged(object sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == "CategoryFilter")
+                VocabListVm.Category = CategoryFilterVm.CategoryFilter;
         }
 
         /// <summary>

--- a/Kanji.Interface/ViewModels/Partial/Kanji/KanjiFilterViewModel.cs
+++ b/Kanji.Interface/ViewModels/Partial/Kanji/KanjiFilterViewModel.cs
@@ -462,7 +462,9 @@ namespace Kanji.Interface.ViewModels
 
             if (uniqueResult != null)
             {
-                if (!Radicals.SelectedItems.Contains(uniqueResult))
+                // Remove(...) returns false if it was not in the list in the first place; this way,
+                // pressing Enter when the radical was already selected will remove it, otherwise it will be added.
+                if (!Radicals.SelectedItems.Remove(uniqueResult))
                 {
                     Radicals.SelectedItems.Add(uniqueResult);
                 }

--- a/Kanji.Interface/ViewModels/Partial/Kanji/KanjiFilterViewModel.cs
+++ b/Kanji.Interface/ViewModels/Partial/Kanji/KanjiFilterViewModel.cs
@@ -224,18 +224,8 @@ namespace Kanji.Interface.ViewModels
 
         public RelayCommand FilterModeChangedCommand { get; set; }
         public RelayCommand SendMainFilterCommand { get; set; }
-        public RelayCommand SendTextFilterCommand { get; set; }
         public RelayCommand SendRadicalFilterCommand { get; set; }
         public RelayCommand<RadicalSortModeEnum> SetRadicalSortModeCommand { get; set; }
-        
-        /// <summary>
-        /// Command used to validate the JLPT & WK level filters.
-        /// </summary>
-        /// <remarks>
-        /// This is a shared command named like this because the control shared with
-        /// the SRS tab wants the command to have this name.
-        /// </remarks>
-        public RelayCommand FilterChangedCommand { get; set; }
 
         #endregion
 
@@ -263,10 +253,8 @@ namespace Kanji.Interface.ViewModels
 
             FilterModeChangedCommand = new RelayCommand(OnFilterModeChanged);
             SendMainFilterCommand = new RelayCommand(OnSendMainFilter);
-            SendTextFilterCommand = new RelayCommand(OnSendTextFilter);
             SendRadicalFilterCommand = new RelayCommand(OnSendRadicalFilter);
             SetRadicalSortModeCommand = new RelayCommand<RadicalSortModeEnum>(OnSetRadicalSortMode);
-	        FilterChangedCommand = new RelayCommand(DoFilterChange);
 
             RadicalStore.Instance.IssueWhenLoaded(OnRadicalsLoaded);
         }
@@ -293,6 +281,14 @@ namespace Kanji.Interface.ViewModels
                 radical.IsSelected = false;
             }
 
+            DoFilterChange();
+        }
+
+        /// <summary>
+        /// Applies the filter.
+        /// </summary>
+        public void ApplyFilter()
+        {
             DoFilterChange();
         }
 
@@ -407,11 +403,6 @@ namespace Kanji.Interface.ViewModels
                 // Change main filter to kana when searching for a reading.
                 MainFilter = KanaHelper.RomajiToKana(MainFilter);
             }
-
-            if (!string.IsNullOrWhiteSpace(MainFilter))
-            {
-                DoFilterChange();
-            }
         }
 
         /// <summary>
@@ -424,16 +415,6 @@ namespace Kanji.Interface.ViewModels
                 // Change input to kana when searching for a reading.
                 MainFilter = KanaHelper.RomajiToKana(MainFilter);
             }
-
-            DoFilterChange();
-        }
-
-        /// <summary>
-        /// Called when the text filter is validated.
-        /// </summary>
-        private void OnSendTextFilter()
-        {
-            DoFilterChange();
         }
 
         /// <summary>

--- a/Kanji.Interface/ViewModels/Partial/Srs/SrsReviewViewModel.cs
+++ b/Kanji.Interface/ViewModels/Partial/Srs/SrsReviewViewModel.cs
@@ -21,7 +21,7 @@ namespace Kanji.Interface.ViewModels
     {
         #region Constants
 
-        private static readonly int BatchMaxSize = 7;
+        private static readonly int BatchMaxSize = 10;
 
         private static readonly int[] MeaningDistanceLenience =
             new int[] { 0, 4, 7, 12, 20 };
@@ -792,6 +792,7 @@ namespace Kanji.Interface.ViewModels
         private void OnWrapUp()
         {
             IsWrappingUp = true;
+			TotalReviewsCount = AnsweredReviewsCount + _currentBatch.Count;
         }
 
         /// <summary>

--- a/Kanji.Interface/ViewModels/Partial/Srs/SrsReviewViewModel.cs
+++ b/Kanji.Interface/ViewModels/Partial/Srs/SrsReviewViewModel.cs
@@ -792,7 +792,7 @@ namespace Kanji.Interface.ViewModels
         private void OnWrapUp()
         {
             IsWrappingUp = true;
-			TotalReviewsCount = AnsweredReviewsCount + _currentBatch.Count;
+            TotalReviewsCount = AnsweredReviewsCount + _currentBatch.Count;
         }
 
         /// <summary>

--- a/Kanji.Interface/ViewModels/Partial/Srs/SrsReviewViewModel.cs
+++ b/Kanji.Interface/ViewModels/Partial/Srs/SrsReviewViewModel.cs
@@ -854,7 +854,8 @@ namespace Kanji.Interface.ViewModels
                         // for review. Remove the question group from the batch.
                         ReviewState = SrsReviewStateEnum.Ignore;
                         _currentBatch.Remove(CurrentQuestionGroup);
-                        FillCurrentBatch();
+						if (!IsWrappingUp)
+							FillCurrentBatch();
 
                         AnsweredReviewsCount++;
                         ToNextQuestion();

--- a/Kanji.Interface/ViewModels/Partial/Vocab/VocabFilterViewModel.cs
+++ b/Kanji.Interface/ViewModels/Partial/Vocab/VocabFilterViewModel.cs
@@ -138,28 +138,9 @@ namespace Kanji.Interface.ViewModels
         #region Commands
 
         /// <summary>
-        /// Command used to validate the reading filter.
+        /// Command used apply the filter.
         /// </summary>
-        public RelayCommand SendReadingFilterCommand { get; set; }
-
-        /// <summary>
-        /// Command used to validate the JLPT & WK level filters.
-        /// </summary>
-        /// <remarks>
-        /// This is a shared command named like this because the control shared with
-        /// the SRS tab wants the command to have this name.
-        /// </remarks>
-        public RelayCommand FilterChangedCommand { get; set; }
-
-        /// <summary>
-        /// Command used to validate the meaning filter.
-        /// </summary>
-        public RelayCommand SendMeaningFilterCommand { get; set; }
-
-        /// <summary>
-        /// Command used to validate the category filter.
-        /// </summary>
-        public RelayCommand SendCategoryFilterCommand { get; set; }
+        public RelayCommand ApplyFilterCommand { get; set; }
         
         /// <summary>
         /// Command used to clear the category filter.
@@ -198,10 +179,7 @@ namespace Kanji.Interface.ViewModels
         {
 	        _filter = filter;
             
-	        FilterChangedCommand = new RelayCommand(IssueFilterChangedEvent);
-	        SendReadingFilterCommand = new RelayCommand(OnSendReadingFilter);
-            SendMeaningFilterCommand = new RelayCommand(OnSendMeaningFilter);
-            SendCategoryFilterCommand = new RelayCommand(OnSendCategoryFilter);
+	        ApplyFilterCommand = new RelayCommand(IssueFilterChangedEvent);
             ClearCategoryFilterCommand = new RelayCommand(OnClearCategoryFilter);
             SwitchCommonOrderCommand = new RelayCommand(OnSwitchCommonOrder);
             SwitchWritingLengthOrderCommand = new RelayCommand(OnSwitchWritingLengthOrder);
@@ -223,38 +201,10 @@ namespace Kanji.Interface.ViewModels
         }
 
         #region Command callbacks
-
-        /// <summary>
-        /// Command callback.
-        /// Issues a filter changed event.
-        /// </summary>
-        private void OnSendReadingFilter()
-        {
-            IssueFilterChangedEvent();
-        }
-
-        /// <summary>
-        /// Command callback.
-        /// Issues a filter changed event.
-        /// </summary>
-        private void OnSendMeaningFilter()
-        {
-            IssueFilterChangedEvent();
-        }
-
-        /// <summary>
-        /// Command callback.
-        /// Issues a filter changed event.
-        /// </summary>
-        private void OnSendCategoryFilter()
-        {
-            IssueFilterChangedEvent();
-        }
         
         private void OnClearCategoryFilter()
         {
             CategoryFilter = null;
-            IssueFilterChangedEvent();
         }
 
         /// <summary>
@@ -264,7 +214,6 @@ namespace Kanji.Interface.ViewModels
         private void OnSwitchCommonOrder()
         {
             IsCommonFirst = !IsCommonFirst;
-            IssueFilterChangedEvent();
         }
 
         /// <summary>
@@ -274,7 +223,6 @@ namespace Kanji.Interface.ViewModels
         private void OnSwitchWritingLengthOrder()
         {
             IsShortReadingFirst = !IsShortReadingFirst;
-            IssueFilterChangedEvent();
         }
         
         #endregion

--- a/Kanji.Interface/ViewModels/Partial/Vocab/VocabFilterViewModel.cs
+++ b/Kanji.Interface/ViewModels/Partial/Vocab/VocabFilterViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -18,6 +19,8 @@ namespace Kanji.Interface.ViewModels
         #endregion
 
         #region Properties
+
+        public CategoryFilterViewModel CategoryFilterVm { get; set; }
         
         /// <summary>
         /// Gets or sets the reading filter applied to the vocab list.
@@ -61,6 +64,7 @@ namespace Kanji.Interface.ViewModels
             {
                 if (_filter.Category != value)
                 {
+                    CategoryFilterVm.CategoryFilter = value;
                     _filter.Category = value;
                     RaisePropertyChanged();
                 }
@@ -178,7 +182,10 @@ namespace Kanji.Interface.ViewModels
         public VocabFilterViewModel(VocabFilter filter)
         {
 	        _filter = filter;
-            
+
+            CategoryFilterVm = new CategoryFilterViewModel();
+            CategoryFilterVm.PropertyChanged += OnCategoryChanged;
+
 	        ApplyFilterCommand = new RelayCommand(IssueFilterChangedEvent);
             ClearCategoryFilterCommand = new RelayCommand(OnClearCategoryFilter);
             SwitchCommonOrderCommand = new RelayCommand(OnSwitchCommonOrder);
@@ -188,6 +195,12 @@ namespace Kanji.Interface.ViewModels
         #endregion
 
         #region Methods
+
+        private void OnCategoryChanged(object sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == "CategoryFilter")
+                CategoryFilter = CategoryFilterVm.CategoryFilter;
+        }
 
         /// <summary>
         /// Issues a filter changed event if the event is not null.

--- a/Kanji.Interface/ViewResources/Style.xaml
+++ b/Kanji.Interface/ViewResources/Style.xaml
@@ -587,38 +587,38 @@
 
     <Style TargetType="Button" BasedOn="{StaticResource MiniActionButton}" x:Key="VocabAudioButton">
         <Style.Triggers>
-            <DataTrigger Binding="{Binding CurrentQuestion.ParentGroup.Audio.State}" Value="Loading">
+            <DataTrigger Binding="{Binding State}" Value="Loading">
                 <Setter Property="Content" Value="(Loading)" />
             </DataTrigger>
-            <DataTrigger Binding="{Binding CurrentQuestion.ParentGroup.Audio.State}" Value="Playing">
+            <DataTrigger Binding="{Binding State}" Value="Playing">
                 <Setter Property="Content" Value="(Playing)" />
             </DataTrigger>
-            <DataTrigger Binding="{Binding CurrentQuestion.ParentGroup.Audio.State}" Value="Failed">
+            <DataTrigger Binding="{Binding State}" Value="Failed">
                 <Setter Property="Content" Value="(Failed)" />
                 <Setter Property="BorderBrush" Value="DarkRed" />
             </DataTrigger>
-            <DataTrigger Binding="{Binding CurrentQuestion.ParentGroup.Audio.State}" Value="Unavailable">
+            <DataTrigger Binding="{Binding State}" Value="Unavailable">
                 <Setter Property="Content" Value="(No audio)" />
                 <Setter Property="BorderBrush" Value="DarkRed" />
             </DataTrigger>
             <MultiDataTrigger>
                 <MultiDataTrigger.Conditions>
                     <Condition Binding="{Binding IsBusy, Source={x:Static business:AudioBusiness.Instance}}" Value="False" />
-                    <Condition Binding="{Binding CurrentQuestion.ParentGroup.Audio.State}" Value="Unknown" />
+                    <Condition Binding="{Binding State}" Value="Unknown" />
                 </MultiDataTrigger.Conditions>
                 <Setter Property="IsEnabled" Value="True" />
             </MultiDataTrigger>
             <MultiDataTrigger>
                 <MultiDataTrigger.Conditions>
                     <Condition Binding="{Binding IsBusy, Source={x:Static business:AudioBusiness.Instance}}" Value="False" />
-                    <Condition Binding="{Binding CurrentQuestion.ParentGroup.Audio.State}" Value="Playable" />
+                    <Condition Binding="{Binding State}" Value="Playable" />
                 </MultiDataTrigger.Conditions>
                 <Setter Property="IsEnabled" Value="True" />
             </MultiDataTrigger>
             <MultiDataTrigger>
                 <MultiDataTrigger.Conditions>
                     <Condition Binding="{Binding IsBusy, Source={x:Static business:AudioBusiness.Instance}}" Value="False" />
-                    <Condition Binding="{Binding CurrentQuestion.ParentGroup.Audio.State}" Value="Failed" />
+                    <Condition Binding="{Binding State}" Value="Failed" />
                 </MultiDataTrigger.Conditions>
                 <Setter Property="IsEnabled" Value="True" />
             </MultiDataTrigger>
@@ -634,7 +634,7 @@
         <Setter Property="Opacity" Value="0.35" />
         <Setter Property="BorderBrush" Value="Transparent" />
         <Setter Property="Command" Value="{Binding PlayVocabAudioCommand, Source={x:Static business:AudioBusiness.Instance}}" />
-        <Setter Property="CommandParameter" Value="{Binding CurrentQuestion.ParentGroup.Audio}" />
+        <Setter Property="CommandParameter" Value="{Binding Audio}" />
     </Style>
 
     <Style TargetType="{x:Type TextBox}" x:Key="KanjiMeaningLabel" BasedOn="{StaticResource LabelBox}">
@@ -1452,7 +1452,7 @@
                                             
                                                     <!-- Audio button -->
                                                     <Button Grid.Column="0" HorizontalAlignment="Left" Style="{StaticResource VocabAudioButton}"
-				                                        DataContext="{Binding Audio}">
+				                                        DataContext="{Binding .}">
                                                         <Button.LayoutTransform>
                                                             <RotateTransform Angle="-90" />
                                                         </Button.LayoutTransform>

--- a/Kanji.Interface/ViewResources/Style.xaml
+++ b/Kanji.Interface/ViewResources/Style.xaml
@@ -587,38 +587,38 @@
 
     <Style TargetType="Button" BasedOn="{StaticResource MiniActionButton}" x:Key="VocabAudioButton">
         <Style.Triggers>
-            <DataTrigger Binding="{Binding State}" Value="Loading">
+            <DataTrigger Binding="{Binding CurrentQuestion.ParentGroup.Audio.State}" Value="Loading">
                 <Setter Property="Content" Value="(Loading)" />
             </DataTrigger>
-            <DataTrigger Binding="{Binding State}" Value="Playing">
+            <DataTrigger Binding="{Binding CurrentQuestion.ParentGroup.Audio.State}" Value="Playing">
                 <Setter Property="Content" Value="(Playing)" />
             </DataTrigger>
-            <DataTrigger Binding="{Binding State}" Value="Failed">
+            <DataTrigger Binding="{Binding CurrentQuestion.ParentGroup.Audio.State}" Value="Failed">
                 <Setter Property="Content" Value="(Failed)" />
                 <Setter Property="BorderBrush" Value="DarkRed" />
             </DataTrigger>
-            <DataTrigger Binding="{Binding State}" Value="Unavailable">
+            <DataTrigger Binding="{Binding CurrentQuestion.ParentGroup.Audio.State}" Value="Unavailable">
                 <Setter Property="Content" Value="(No audio)" />
                 <Setter Property="BorderBrush" Value="DarkRed" />
             </DataTrigger>
             <MultiDataTrigger>
                 <MultiDataTrigger.Conditions>
                     <Condition Binding="{Binding IsBusy, Source={x:Static business:AudioBusiness.Instance}}" Value="False" />
-                    <Condition Binding="{Binding State}" Value="Unknown" />
+                    <Condition Binding="{Binding CurrentQuestion.ParentGroup.Audio.State}" Value="Unknown" />
                 </MultiDataTrigger.Conditions>
                 <Setter Property="IsEnabled" Value="True" />
             </MultiDataTrigger>
             <MultiDataTrigger>
                 <MultiDataTrigger.Conditions>
                     <Condition Binding="{Binding IsBusy, Source={x:Static business:AudioBusiness.Instance}}" Value="False" />
-                    <Condition Binding="{Binding State}" Value="Playable" />
+                    <Condition Binding="{Binding CurrentQuestion.ParentGroup.Audio.State}" Value="Playable" />
                 </MultiDataTrigger.Conditions>
                 <Setter Property="IsEnabled" Value="True" />
             </MultiDataTrigger>
             <MultiDataTrigger>
                 <MultiDataTrigger.Conditions>
                     <Condition Binding="{Binding IsBusy, Source={x:Static business:AudioBusiness.Instance}}" Value="False" />
-                    <Condition Binding="{Binding State}" Value="Failed" />
+                    <Condition Binding="{Binding CurrentQuestion.ParentGroup.Audio.State}" Value="Failed" />
                 </MultiDataTrigger.Conditions>
                 <Setter Property="IsEnabled" Value="True" />
             </MultiDataTrigger>
@@ -634,7 +634,7 @@
         <Setter Property="Opacity" Value="0.35" />
         <Setter Property="BorderBrush" Value="Transparent" />
         <Setter Property="Command" Value="{Binding PlayVocabAudioCommand, Source={x:Static business:AudioBusiness.Instance}}" />
-        <Setter Property="CommandParameter" Value="{Binding .}" />
+        <Setter Property="CommandParameter" Value="{Binding CurrentQuestion.ParentGroup.Audio}" />
     </Style>
 
     <Style TargetType="{x:Type TextBox}" x:Key="KanjiMeaningLabel" BasedOn="{StaticResource LabelBox}">

--- a/Kanji.Interface/Views/EditSrsEntryWindow.xaml
+++ b/Kanji.Interface/Views/EditSrsEntryWindow.xaml
@@ -227,7 +227,7 @@
             <StackPanel Grid.Row="2" Margin="0 5 3 0">
                 <TextBlock Style="{StaticResource LegendText}" Text="Accepted meanings:" />
                 <TextBox Height="40" MaxLength="300" TextWrapping="Wrap"
-                         Text="{Binding Entry.Meanings, Mode=TwoWay}"
+                         Text="{Binding Entry.Meanings, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                          ToolTip="Meanings separated with a comma." />
             </StackPanel>
 
@@ -235,7 +235,7 @@
             <StackPanel Grid.Row="2" Grid.Column="1" Margin="3 5 0 0">
                 <TextBlock Style="{StaticResource LegendText}" Text="Accepted readings:" />
                 <TextBox Height="40" MaxLength="100" TextWrapping="Wrap"
-                         Text="{Binding Entry.Readings, Mode=TwoWay}"
+                         Text="{Binding Entry.Readings, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                          ToolTip="Readings separated with a comma.">
                     <TextBox.LayoutTransform>
                         <ScaleTransform ScaleX="1.2" />
@@ -252,7 +252,7 @@
                 <TextBlock Style="{StaticResource LegendText}" Text="Meaning notes:" />
                 <AdornerDecorator Grid.Row="1">
                     <TextBox MaxLength="1000" AcceptsReturn="True" TextWrapping="Wrap"
-                             Text="{Binding Entry.MeaningNote, Mode=TwoWay}">
+                             Text="{Binding Entry.MeaningNote, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
                         <controls:WatermarkService.Watermark>
                             <TextBlock HorizontalAlignment="Center" TextAlignment="Center"
                                        VerticalAlignment="Center" TextWrapping="Wrap"
@@ -274,7 +274,7 @@
                 <TextBlock Style="{StaticResource LegendText}" Text="Reading notes:" />
                 <AdornerDecorator Grid.Row="1">
                     <TextBox MaxLength="1000" AcceptsReturn="True" TextWrapping="Wrap"
-                             Text="{Binding Entry.ReadingNote, Mode=TwoWay}">
+                             Text="{Binding Entry.ReadingNote, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
                         <controls:WatermarkService.Watermark>
                             <TextBlock HorizontalAlignment="Center" TextAlignment="Center"
                                        VerticalAlignment="Center" TextWrapping="Wrap"
@@ -291,14 +291,14 @@
             <StackPanel Grid.Row="4" Grid.ColumnSpan="2" Margin="0 5 0 5">
                 <TextBlock Style="{StaticResource LegendText}" Text="Tags (optional):" />
                 <TextBox Height="40" MaxLength="300" TextWrapping="Wrap"
-                         Text="{Binding Entry.Tags, Mode=TwoWay}"
+                         Text="{Binding Entry.Tags, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                          ToolTip="Tags must be separated with a comma. Tags can be anything you want and are used for filtering purposes. Leave blank if you are not sure." />
             </StackPanel>
             
             <!-- Action button row -->
             <UniformGrid Grid.Row="5" Grid.ColumnSpan="2" Rows="1">
                 <Button Style="{StaticResource MiniActionButton}" Content="Cancel changes" Margin="3 5 3 0"
-                    Command="{Binding CancelCommand}" IsCancel="True" ToolTip="Cancel any changes you have made (CTRL+Escape)." />
+                    Command="{Binding CancelCommand}" IsCancel="True" ToolTip="Cancel any changes you have made (Escape)." />
                 <Button Content="Delete this item" Margin="0 5 3 0"
                     Command="{Binding DeleteCommand}" ToolTip="Delete this SRS item (CTRL+Delete).">
                     <Button.Style>

--- a/Kanji.Interface/Views/EditSrsEntryWindow.xaml
+++ b/Kanji.Interface/Views/EditSrsEntryWindow.xaml
@@ -234,13 +234,13 @@
             <!-- Readings field -->
             <StackPanel Grid.Row="2" Grid.Column="1" Margin="3 5 0 0">
                 <TextBlock Style="{StaticResource LegendText}" Text="Accepted readings:" />
-                <TextBox Height="40" MaxLength="100" TextWrapping="Wrap"
-                         Text="{Binding Entry.Readings, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                         ToolTip="Readings separated with a comma.">
-                    <TextBox.LayoutTransform>
-                        <ScaleTransform ScaleX="1.2" />
-                    </TextBox.LayoutTransform>
-                </TextBox>
+                <controls:CommandTextBox Text="{Binding Entry.Readings, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                         Height="40" MaxLength="100" TextWrapping="Wrap" IsKanaInput="True"
+                                         ToolTip="Readings separated with a comma.">
+                    <controls:WatermarkService.Watermark>
+                        <TextBlock />
+                    </controls:WatermarkService.Watermark>
+                </controls:CommandTextBox>
             </StackPanel>
             
             <!-- Meaning notes field -->

--- a/Kanji.Interface/Views/EditSrsEntryWindow.xaml
+++ b/Kanji.Interface/Views/EditSrsEntryWindow.xaml
@@ -4,7 +4,7 @@
         xmlns:controls="clr-namespace:Kanji.Interface.Controls"
         xmlns:converters="clr-namespace:Kanji.Interface.Converters"
         xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
-        Height="500" Width="500">
+        Height="500" Width="500" KeyDown="OnKeyDown">
     <Window.Style>
         <Style TargetType="Window">
             <Style.Triggers>
@@ -176,10 +176,10 @@
                             Mode=OneWay}"
                                  Visibility="{Binding IsEditingDate, Converter={StaticResource ValueToVisibilityConverter}, ConverterParameter=False}" />
 
-                        <xctk:DateTimePicker Grid.Column="1" Value="{Binding Entry.NextAnswerDate}" Format="FullDateTime"
-                            TextAlignment="Left" Visibility="{Binding IsEditingDate, Converter={StaticResource ValueToVisibilityConverter}}"  />
+                        <xctk:DateTimePicker x:Name="ReviewDatePicker" Grid.Column="1" Value="{Binding Entry.NextAnswerDate}" Format="FullDateTime"
+                            TextAlignment="Left" Visibility="{Binding IsEditingDate, Converter={StaticResource ValueToVisibilityConverter}}" Focusable="True"  />
                         
-                        <Button Grid.Column="2" Command="{Binding ToggleDateEditCommand}" Margin="10 0 0 0" Width="70" HorizontalAlignment="Right">
+                        <Button Grid.Column="2" Command="{Binding ToggleDateEditCommand}" Margin="10 0 0 0" Width="70" HorizontalAlignment="Right" ToolTip="Edit the next review date manually (CTRL+E).">
                             <Button.Style>
                                 <Style TargetType="Button" BasedOn="{StaticResource MiniActionButton}">
                                     <Style.Triggers>
@@ -196,20 +196,20 @@
                         
                         <UniformGrid Columns="3" Grid.Row="1" Grid.ColumnSpan="3" Margin="0 3 0 0">
                             <Button Style="{StaticResource MiniActionButton}" Command="{Binding DateToNowCommand}"
-                                Content="Reset date" ToolTip="Set the next review date to now." />
+                                Content="Reset date" ToolTip="Set the next review date to now (CTRL+R)." />
                             <Button Style="{StaticResource MiniActionButton}" Command="{Binding DateToNeverCommand}"
-                                Content="Never review" ToolTip="Set the next review date to never." Margin="5 0" />
+                                Content="Never review" ToolTip="Set the next review date to never (CTRL+N)." Margin="5 0" />
                             <Button Command="{Binding ToggleSuspendCommand}">
                                 <Button.Style>
                                     <Style TargetType="Button" BasedOn="{StaticResource MiniActionButton}">
                                         <Style.Triggers>
                                             <DataTrigger Binding="{Binding Entry.SuspensionDate}" Value="{x:Null}">
                                                 <Setter Property="Content" Value="Suspend" />
-                                                <Setter Property="ToolTip" Value="Suspends the item. The item will not appear in reviews until you resume it." />
+                                                <Setter Property="ToolTip" Value="Suspends the item. The item will not appear in reviews until you resume it (CTRL+S)." />
                                             </DataTrigger>
                                         </Style.Triggers>
                                         <Setter Property="Content" Value="Resume" />
-                                        <Setter Property="ToolTip" Value="Resumes the SRS progression." />
+                                        <Setter Property="ToolTip" Value="Resumes the SRS progression (CTRL+S)." />
                                     </Style>
                                 </Button.Style>
                             </Button>
@@ -298,9 +298,9 @@
             <!-- Action button row -->
             <UniformGrid Grid.Row="5" Grid.ColumnSpan="2" Rows="1">
                 <Button Style="{StaticResource MiniActionButton}" Content="Cancel changes" Margin="3 5 3 0"
-                    Command="{Binding CancelCommand}" />
+                    Command="{Binding CancelCommand}" IsCancel="True" ToolTip="Cancel any changes you have made (CTRL+Escape)." />
                 <Button Content="Delete this item" Margin="0 5 3 0"
-                    Command="{Binding DeleteCommand}">
+                    Command="{Binding DeleteCommand}" ToolTip="Delete this SRS item (CTRL+Delete).">
                     <Button.Style>
                         <Style TargetType="Button" BasedOn="{StaticResource MiniActionButton}">
                             <Style.Triggers>
@@ -311,7 +311,7 @@
                         </Style>
                     </Button.Style>
                 </Button>
-                <Button Margin="3 5 0 0" Command="{Binding SubmitCommand}">
+                <Button Margin="3 5 0 0" Command="{Binding SubmitCommand}" ToolTip="Save the changes you have made (CTRL+Enter).">
                     <Button.Style>
                         <Style TargetType="Button" BasedOn="{StaticResource ActionButton}">
                             <Style.Triggers>

--- a/Kanji.Interface/Views/EditSrsEntryWindow.xaml.cs
+++ b/Kanji.Interface/Views/EditSrsEntryWindow.xaml.cs
@@ -117,6 +117,51 @@ namespace Kanji.Interface.Views
             NavigationActor.Instance.ActiveWindow = NavigationActor.Instance.MainWindow;
         }
 
+        /// <summary>
+        /// Since a <see cref="GalaSoft.MvvmLight.Command.RelayCommand"/> does not accept keyboard shortcuts,
+        /// we have to manually invoke the commands on a keyboard event.
+        /// </summary>
+        private void OnKeyDown(object sender, KeyEventArgs e)
+        {
+            /* 
+			 * - CTRL+Enter -> SubmitCommand
+			 * - CTRL+Delete -> DeleteCommand
+             * - CTRL+R -> DateToNowCommand
+             * - CTRL+N -> DateToNeverCommand
+             * - CTRL+E -> ToggleDateEditCommand
+			 */
+
+            KeyboardDevice keyboardDevice = e.KeyboardDevice;
+
+            if (keyboardDevice.IsKeyDown(Key.LeftCtrl) || keyboardDevice.IsKeyDown(Key.RightCtrl))
+            {
+                SrsEntryViewModel viewModel = ((SrsEntryViewModel)DataContext);
+                switch (e.Key)
+                {
+                    case Key.Enter:
+                        viewModel.SubmitCommand.Execute(null);
+                        break;
+                    case Key.Delete:
+                        viewModel.DeleteCommand.Execute(null);
+                        break;
+                    case Key.R:
+                        viewModel.DateToNowCommand.Execute(null);
+                        break;
+                    case Key.N:
+                        viewModel.DateToNeverCommand.Execute(null);
+                        break;
+                    case Key.E:
+                        viewModel.ToggleDateEditCommand.Execute(null);
+                        if (viewModel.IsEditingDate)
+                            ReviewDatePicker.Focus();
+                        break;
+                    case Key.S:
+                        viewModel.ToggleSuspendCommand.Execute(null);
+                        break;
+                }
+            }
+        }
+
         #endregion
     }
 }

--- a/Kanji.Interface/Views/EditSrsEntryWindow.xaml.cs
+++ b/Kanji.Interface/Views/EditSrsEntryWindow.xaml.cs
@@ -140,23 +140,29 @@ namespace Kanji.Interface.Views
                 {
                     case Key.Enter:
                         viewModel.SubmitCommand.Execute(null);
+                        e.Handled = true;
                         break;
                     case Key.Delete:
                         viewModel.DeleteCommand.Execute(null);
+                        e.Handled = true;
                         break;
                     case Key.R:
                         viewModel.DateToNowCommand.Execute(null);
+                        e.Handled = true;
                         break;
                     case Key.N:
                         viewModel.DateToNeverCommand.Execute(null);
+                        e.Handled = true;
                         break;
                     case Key.E:
                         viewModel.ToggleDateEditCommand.Execute(null);
                         if (viewModel.IsEditingDate)
                             ReviewDatePicker.Focus();
+                        e.Handled = true;
                         break;
                     case Key.S:
                         viewModel.ToggleSuspendCommand.Execute(null);
+                        e.Handled = true;
                         break;
                 }
             }

--- a/Kanji.Interface/Views/HomePage.xaml
+++ b/Kanji.Interface/Views/HomePage.xaml
@@ -6,8 +6,8 @@
              xmlns:controls="clr-namespace:Kanji.Interface.Controls"
              xmlns:business="clr-namespace:Kanji.Interface.Business"
              xmlns:toolkit="WPF"
-             mc:Ignorable="d" 
-             d:DesignHeight="400" d:DesignWidth="900">
+             mc:Ignorable="d" Focusable="true"
+             d:DesignHeight="400" d:DesignWidth="900" KeyDown="OnKeyDown" IsVisibleChanged="OnIsVisibleChanged">
 
     <DockPanel>
         <controls:NavigationBar DockPanel.Dock="Top" />

--- a/Kanji.Interface/Views/HomePage.xaml.cs
+++ b/Kanji.Interface/Views/HomePage.xaml.cs
@@ -18,15 +18,50 @@ namespace Kanji.Interface.Views
 {
     public partial class HomePage : UserControl
     {
+        #region Constructors
+
         public HomePage()
         {
             InitializeComponent();
             DataContext = new HomeViewModel();
         }
 
+        #endregion
+
+        #region Methods
+        
         private void OnRequestNavigate(object sender, RequestNavigateEventArgs e)
         {
             System.Diagnostics.Process.Start(e.Uri.ToString());
         }
+
+        /// <summary>
+        /// Since a <see cref="GalaSoft.MvvmLight.Command.RelayCommand"/> does not accept keyboard shortcuts,
+        /// we have to manually invoke the commands on a keyboard event.
+        /// </summary>
+        private void OnKeyDown(object sender, KeyEventArgs e)
+        {
+            KeyboardDevice keyboardDevice = e.KeyboardDevice;
+
+            if (keyboardDevice.IsKeyDown(Key.LeftCtrl) || keyboardDevice.IsKeyDown(Key.RightCtrl))
+            {
+                switch (e.Key)
+                {
+
+                }
+            }
+        }
+
+        private void OnIsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e)
+        {
+            // Focus the page once it becomes visible.
+            // This is so that the navigation bar does not keep the focus, which would prevent shortcut keys from working.
+            if (((bool)e.NewValue))
+            {
+                Focus();
+            }
+        }
+
+        #endregion
     }
 }

--- a/Kanji.Interface/Views/KanjiPage.xaml
+++ b/Kanji.Interface/Views/KanjiPage.xaml
@@ -116,11 +116,14 @@
                             <Button.Style>
                                 <Style TargetType="Button" BasedOn="{StaticResource MiniActionButton}">
                                     <Style.Triggers>
-                                        <DataTrigger Binding="{Binding CanNavigateBack}" Value="False">
+                                        <DataTrigger Binding="{Binding CanNavigateBack}" Value="True">
+                                            <Setter Property="Visibility" Value="Collapsed" />
+                                        </DataTrigger>
+                                        <DataTrigger Binding="{Binding CanApplyFilter}" Value="True">
                                             <Setter Property="Visibility" Value="Visible" />
                                         </DataTrigger>
                                     </Style.Triggers>
-                                    <Setter Property="Visibility" Value="Collapsed" />
+                                    <Setter Property="Visibility" Value="Hidden" />
                                 </Style>
                             </Button.Style>
                         </Button>

--- a/Kanji.Interface/Views/KanjiPage.xaml
+++ b/Kanji.Interface/Views/KanjiPage.xaml
@@ -82,22 +82,22 @@
                                 </Style>
                             </Button.Style>
                         </Button>
-                        <Button Content="Clear all filters"
-                            Command="{Binding ClearFilterCommand}" Margin="0,0,0,5">
-                            <Button.Style>
-                                <Style TargetType="Button" BasedOn="{StaticResource ActionButton}">
-                                    <Style.Triggers>
-                                        <DataTrigger Binding="{Binding KanjiFilterVm.Radicals}" Value="{x:Null}">
-                                            <Setter Property="IsEnabled" Value="False" />
-                                        </DataTrigger>
-                                        <DataTrigger Binding="{Binding ElementName=CloseKanjiPageButton, Path=Visibility}"
-                                            Value="Visible">
-                                            <Setter Property="Visibility" Value="Collapsed" />
-                                        </DataTrigger>
-                                    </Style.Triggers>
-                                </Style>
-                            </Button.Style>
-                        </Button>
+                        <Button x:Name="ClearFilterButton" Content="Clear all filters" ToolTip="(CTRL+Shift+C)"
+                                Command="{Binding ClearFilterCommand}" Margin="0,0,0,5">
+                                <Button.Style>
+                                    <Style TargetType="Button" BasedOn="{StaticResource ActionButton}">
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding KanjiFilterVm.Radicals}" Value="{x:Null}">
+                                                <Setter Property="IsEnabled" Value="False" />
+                                            </DataTrigger>
+                                            <DataTrigger Binding="{Binding ElementName=CloseKanjiPageButton, Path=Visibility}"
+                                                Value="Visible">
+                                                <Setter Property="Visibility" Value="Collapsed" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Button.Style>
+                            </Button>
 
                         <Button Content="Navigate back" Command="{Binding NavigateBackCommand}" Margin="0,0,0,5">
                             <Button.Style>
@@ -107,7 +107,20 @@
                                             <Setter Property="Visibility" Value="Visible" />
                                         </DataTrigger>
                                     </Style.Triggers>
-                                    <Setter Property="Visibility" Value="Hidden" />
+                                    <Setter Property="Visibility" Value="Collapsed" />
+                                </Style>
+                            </Button.Style>
+                        </Button>
+                        <Button x:Name="ApplyFilterButton" Command="{Binding ApplyFilterCommand}" Margin="0,0,0,5"
+                                Content="Apply Filter" ToolTip="(Enter or CTRL+Enter)" >
+                            <Button.Style>
+                                <Style TargetType="Button" BasedOn="{StaticResource MiniActionButton}">
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding CanNavigateBack}" Value="False">
+                                            <Setter Property="Visibility" Value="Visible" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                    <Setter Property="Visibility" Value="Collapsed" />
                                 </Style>
                             </Button.Style>
                         </Button>

--- a/Kanji.Interface/Views/KanjiPage.xaml
+++ b/Kanji.Interface/Views/KanjiPage.xaml
@@ -7,8 +7,8 @@
       xmlns:cmd="clr-namespace:GalaSoft.MvvmLight.Command;assembly=GalaSoft.MvvmLight.Extras.WPF4"
       xmlns:utilities="clr-namespace:Kanji.Interface.Utilities"
       xmlns:controls="clr-namespace:Kanji.Interface.Controls"
-      mc:Ignorable="d" 
-      d:DesignHeight="300" d:DesignWidth="600">
+      mc:Ignorable="d" Focusable="true"
+      d:DesignHeight="300" d:DesignWidth="600" KeyDown="OnKeyDown" IsVisibleChanged="OnIsVisibleChanged">
 
     <DockPanel>
         <controls:NavigationBar DockPanel.Dock="Top" />
@@ -24,7 +24,7 @@
                 </Grid.RowDefinitions>
             
                 <!-- Filter control panel -->
-                <controls:KanjiFilterControl DataContext="{Binding KanjiFilterVm}">
+                <controls:KanjiFilterControl x:Name="KanjiFilterControl" DataContext="{Binding KanjiFilterVm}">
                     <controls:KanjiFilterControl.Style>
                         <Style TargetType="UserControl">
                             <Style.Triggers>

--- a/Kanji.Interface/Views/KanjiPage.xaml.cs
+++ b/Kanji.Interface/Views/KanjiPage.xaml.cs
@@ -22,5 +22,46 @@ namespace Kanji.Interface.Views
             InitializeComponent();
             DataContext = new KanjiViewModel();
         }
+
+        /// <summary>
+        /// Since a <see cref="GalaSoft.MvvmLight.Command.RelayCommand"/> does not accept keyboard shortcuts,
+        /// we have to manually invoke the commands on a keyboard event.
+        /// </summary>
+        private void OnKeyDown(object sender, KeyEventArgs e)
+        {
+            KeyboardDevice keyboardDevice = e.KeyboardDevice;
+
+            if (keyboardDevice.IsKeyDown(Key.LeftCtrl) || keyboardDevice.IsKeyDown(Key.RightCtrl))
+            {
+                switch (e.Key)
+                {
+                    case Key.R:
+                        KanjiFilterControl.RadicalNameFilter.Focus();
+                        break;
+                    case Key.W:
+                        KanjiFilterControl.WkLevelFilter.LevelSlider.Focus();
+                        break;
+                    case Key.J:
+                        KanjiFilterControl.JlptLevelFilter.LevelSlider.Focus();
+                        break;
+                    case Key.T:
+                        KanjiFilterControl.TextFilter.Focus();
+                        break;
+                    case Key.F:
+                        KanjiFilterControl.Filter.Focus();
+                        break;
+                }
+            }
+        }
+
+        private void OnIsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e)
+        {
+            // Focus the page once it becomes visible.
+            // This is so that the navigation bar does not keep the focus, which would prevent shortcut keys from working.
+            if (((bool)e.NewValue))
+            {
+                Focus();
+            }
+        }
     }
 }

--- a/Kanji.Interface/Views/KanjiPage.xaml.cs
+++ b/Kanji.Interface/Views/KanjiPage.xaml.cs
@@ -55,7 +55,21 @@ namespace Kanji.Interface.Views
                         KanjiFilterControl.Filter.Focus();
                         e.Handled = true;
                         break;
+                    case Key.C:
+                        if (!keyboardDevice.IsKeyDown(Key.LeftShift) && !keyboardDevice.IsKeyDown(Key.RightShift))
+                            break;
+                        ClearFilterButton.Command.Execute(null);
+                        e.Handled = true;
+                        break;
                 }
+            }
+
+            switch (e.Key)
+            {
+                case Key.Enter:
+                    ApplyFilterButton.Command.Execute(null);
+                    e.Handled = true;
+                    break;
             }
         }
 

--- a/Kanji.Interface/Views/KanjiPage.xaml.cs
+++ b/Kanji.Interface/Views/KanjiPage.xaml.cs
@@ -37,18 +37,23 @@ namespace Kanji.Interface.Views
                 {
                     case Key.R:
                         KanjiFilterControl.RadicalNameFilter.Focus();
+                        e.Handled = true;
                         break;
                     case Key.W:
                         KanjiFilterControl.WkLevelFilter.LevelSlider.Focus();
+                        e.Handled = true;
                         break;
                     case Key.J:
                         KanjiFilterControl.JlptLevelFilter.LevelSlider.Focus();
+                        e.Handled = true;
                         break;
                     case Key.T:
                         KanjiFilterControl.TextFilter.Focus();
+                        e.Handled = true;
                         break;
                     case Key.F:
                         KanjiFilterControl.Filter.Focus();
+                        e.Handled = true;
                         break;
                 }
             }

--- a/Kanji.Interface/Views/KanjiPage.xaml.cs
+++ b/Kanji.Interface/Views/KanjiPage.xaml.cs
@@ -17,11 +17,17 @@ namespace Kanji.Interface.Views
 {
     public partial class KanjiPage : UserControl
     {
+        #region Constructors
+
         public KanjiPage()
         {
             InitializeComponent();
             DataContext = new KanjiViewModel();
         }
+
+        #endregion
+
+        #region Methods
 
         /// <summary>
         /// Since a <see cref="GalaSoft.MvvmLight.Command.RelayCommand"/> does not accept keyboard shortcuts,
@@ -29,6 +35,9 @@ namespace Kanji.Interface.Views
         /// </summary>
         private void OnKeyDown(object sender, KeyEventArgs e)
         {
+            if (KanjiDetailsControl.Visibility == Visibility.Visible)
+                return;
+
             KeyboardDevice keyboardDevice = e.KeyboardDevice;
 
             if (keyboardDevice.IsKeyDown(Key.LeftCtrl) || keyboardDevice.IsKeyDown(Key.RightCtrl))
@@ -82,5 +91,7 @@ namespace Kanji.Interface.Views
                 Focus();
             }
         }
+
+        #endregion
     }
 }

--- a/Kanji.Interface/Views/Partial/Common/Filters/CategoryFilterControl.xaml
+++ b/Kanji.Interface/Views/Partial/Common/Filters/CategoryFilterControl.xaml
@@ -13,10 +13,10 @@
         </Grid.ColumnDefinitions>
 
         <ComboBox Name="ComboBox" Margin="5,2" VerticalAlignment="Center" VerticalContentAlignment="Center"
-            FontSize="15" FontWeight="SemiBold"
-            SelectedIndex="{Binding SelectedIndex, ElementName=HiddenList}"
+            FontSize="15" FontWeight="SemiBold" ToolTip="Select the category to filter by (CTRL+ALT+C)."
             behaviors:SelectionChangedBehavior.Command="{Binding FilterChangedCommand}"
-            ToolTip="Select the category to filter by (CTRL+ALT+C)." >
+            DataContext="{Binding CategoryFilterVm}"
+            ItemsSource="{Binding Categories, Mode=OneTime}" SelectedIndex="{Binding SelectedCategoryIndex, Mode=TwoWay}">
             <ComboBox.ItemTemplate>
                 <DataTemplate>
                     <TextBlock Text="{Binding Converter={StaticResource VocabCategoriesToStringConverter}}"
@@ -25,7 +25,6 @@
             </ComboBox.ItemTemplate>
         </ComboBox>
 
-        <ListBox Grid.Column="0" Name="HiddenList" Visibility="Collapsed" SelectedItem="{Binding CategoryFilter, UpdateSourceTrigger=PropertyChanged}"/>
         <Button Style="{StaticResource MiniActionButton}" Command="{Binding ClearCategoryFilterCommand}"
                 Content="Clear" Grid.Column="1"
                 HorizontalAlignment="Left" VerticalAlignment="Center" Padding="2,0" />

--- a/Kanji.Interface/Views/Partial/Common/Filters/CategoryFilterControl.xaml
+++ b/Kanji.Interface/Views/Partial/Common/Filters/CategoryFilterControl.xaml
@@ -15,7 +15,8 @@
         <ComboBox Name="ComboBox" Margin="5,2" VerticalAlignment="Center" VerticalContentAlignment="Center"
             FontSize="15" FontWeight="SemiBold"
             SelectedIndex="{Binding SelectedIndex, ElementName=HiddenList}"
-            behaviors:SelectionChangedBehavior.Command="{Binding FilterChangedCommand}">
+            behaviors:SelectionChangedBehavior.Command="{Binding FilterChangedCommand}"
+            ToolTip="Select the category to filter by (CTRL+ALT+C)." >
             <ComboBox.ItemTemplate>
                 <DataTemplate>
                     <TextBlock Text="{Binding Converter={StaticResource VocabCategoriesToStringConverter}}"

--- a/Kanji.Interface/Views/Partial/Common/Filters/CategoryFilterControl.xaml.cs
+++ b/Kanji.Interface/Views/Partial/Common/Filters/CategoryFilterControl.xaml.cs
@@ -13,11 +13,6 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Navigation;
 using System.Windows.Shapes;
-using Kanji.Database.Dao;
-using Kanji.Database.Entities;
-using Kanji.Database.Models;
-using Kanji.Interface.Converters;
-using Kanji.Interface.Internationalization;
 
 namespace Kanji.Interface.Controls
 {
@@ -26,58 +21,6 @@ namespace Kanji.Interface.Controls
         public CategoryFilterControl()
         {
             InitializeComponent();
-			
-	        VocabDao dao = new VocabDao();
-	        DataContext = dao;
-
-			var converter = new VocabCategoriesToStringConverter();
-	        var allCategories = dao.GetAllCategories().ToList();
-	        var filteredCategories = allCategories.Where(cat =>
-		    {
-				// These are various types of archaic verbs.
-                // We remove these from the category list for two reasons:
-                // 1) The user would see these as individual categories;
-                // 2) None of these categories currently have any vocab words.
-				switch (cat.ShortName)
-                {
-                    case "v4k":
-                    case "v4g":
-                    case "v4s":
-                    case "v4t":
-                    case "v4n":
-                    case "v4b":
-                    case "v4m":
-                    case "v2k-k":
-                    case "v2g-k":
-                    case "v2t-k":
-                    case "v2d-k":
-                    case "v2h-k":
-                    case "v2b-k":
-                    case "v2m-k":
-                    case "v2y-k":
-                    case "v2r-k":
-                    case "v2k-s":
-                    case "v2g-s":
-                    case "v2s-s":
-                    case "v2z-s":
-                    case "v2t-s":
-                    case "v2d-s":
-                    case "v2n-s":
-                    case "v2h-s":
-                    case "v2b-s":
-                    case "v2m-s":
-                    case "v2y-s":
-                    case "v2r-s":
-                    case "v2w-s":
-                        return false;
-                }
-
-                object convertedValue = converter.Convert(cat, null, null, null);
-				return !string.IsNullOrWhiteSpace(convertedValue as string);
-		    }).ToList();
-            
-            HiddenList.ItemsSource = filteredCategories;
-	        ComboBox.ItemsSource = filteredCategories;
         }
     }
 }

--- a/Kanji.Interface/Views/Partial/Common/Filters/JlptLevelFilterControl.xaml
+++ b/Kanji.Interface/Views/Partial/Common/Filters/JlptLevelFilterControl.xaml
@@ -15,7 +15,6 @@
             <ColumnDefinition Width="Auto" />
             <ColumnDefinition Width="Auto" />
             <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="Auto" />
         </Grid.ColumnDefinitions>
 
         <TextBlock Text="JLPT Level" Style="{StaticResource LegendText}" />
@@ -34,8 +33,5 @@
                 <KeyBinding Command="{Binding FilterChangedCommand}" Key="Enter" />
             </Slider.InputBindings>
         </Slider>
-        <Button Style="{StaticResource MiniActionButton}" Command="{Binding FilterChangedCommand}"
-                Content="Filter" Grid.Column="3"
-                HorizontalAlignment="Center" VerticalAlignment="Center" />
     </Grid>
 </UserControl>

--- a/Kanji.Interface/Views/Partial/Common/Filters/JlptLevelFilterControl.xaml
+++ b/Kanji.Interface/Views/Partial/Common/Filters/JlptLevelFilterControl.xaml
@@ -28,7 +28,12 @@
         <Slider x:Name="LevelSlider" Grid.Column="2" VerticalAlignment="Center"
                 Minimum="0" Maximum="6" Value="{Binding JlptLevel, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                 SmallChange="1" IsDirectionReversed="True" MinWidth="50"
-                TickPlacement="BottomRight" IsSnapToTickEnabled="True" Foreground="Black" IsMoveToPointEnabled="True" />
+                TickPlacement="BottomRight" IsSnapToTickEnabled="True" Foreground="Black" IsMoveToPointEnabled="True"
+                ToolTip="Select the JLPT level to filter by (CTRL+J)">
+            <Slider.InputBindings>
+                <KeyBinding Command="{Binding FilterChangedCommand}" Key="Enter" />
+            </Slider.InputBindings>
+        </Slider>
         <Button Style="{StaticResource MiniActionButton}" Command="{Binding FilterChangedCommand}"
                 Content="Filter" Grid.Column="3"
                 HorizontalAlignment="Center" VerticalAlignment="Center" />

--- a/Kanji.Interface/Views/Partial/Common/Filters/WkLevelFilterControl.xaml
+++ b/Kanji.Interface/Views/Partial/Common/Filters/WkLevelFilterControl.xaml
@@ -27,7 +27,12 @@
                    TextAlignment="Center"/>
         <Slider x:Name="LevelSlider" Grid.Column="2" VerticalAlignment="Center"
 			    Minimum="0" Maximum="61" Value="{Binding WkLevel, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" SmallChange="1" LargeChange="10"
-                TickPlacement="BottomRight" IsSnapToTickEnabled="True" Foreground="Black" IsMoveToPointEnabled="True" />
+                TickPlacement="BottomRight" IsSnapToTickEnabled="True" Foreground="Black" IsMoveToPointEnabled="True"
+                ToolTip="Select the WaniKani level to filter by (CTRL+W)">
+            <Slider.InputBindings>
+                <KeyBinding Command="{Binding FilterChangedCommand}" Key="Enter" />
+            </Slider.InputBindings>
+        </Slider>
         <Button Style="{StaticResource MiniActionButton}" Command="{Binding FilterChangedCommand}"
                 Content="Filter" Grid.Column="3"
                 HorizontalAlignment="Center" VerticalAlignment="Center" />

--- a/Kanji.Interface/Views/Partial/Common/Filters/WkLevelFilterControl.xaml
+++ b/Kanji.Interface/Views/Partial/Common/Filters/WkLevelFilterControl.xaml
@@ -15,7 +15,6 @@
             <ColumnDefinition Width="Auto" />
             <ColumnDefinition Width="Auto" />
             <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="Auto" />
         </Grid.ColumnDefinitions>
 
         <TextBlock Text="WaniKani Level" Style="{StaticResource LegendText}" />
@@ -33,8 +32,5 @@
                 <KeyBinding Command="{Binding FilterChangedCommand}" Key="Enter" />
             </Slider.InputBindings>
         </Slider>
-        <Button Style="{StaticResource MiniActionButton}" Command="{Binding FilterChangedCommand}"
-                Content="Filter" Grid.Column="3"
-                HorizontalAlignment="Center" VerticalAlignment="Center" />
     </Grid>
 </UserControl>

--- a/Kanji.Interface/Views/Partial/Common/NavigationBar.xaml
+++ b/Kanji.Interface/Views/Partial/Common/NavigationBar.xaml
@@ -28,7 +28,7 @@
                 <Label Style="{StaticResource NavigationPanelTabTitle}" Content="HOME" />
             </DockPanel>
             <Button Grid.ColumnSpan="2" Style="{StaticResource NavigationPanelButton}" Command="{Binding NavigateCommand}"
-                CommandParameter="{x:Static models:NavigationPageEnum.Home}" />
+                CommandParameter="{x:Static models:NavigationPageEnum.Home}" ToolTip="(CTRL+1)" />
         </Grid>
         
         <!-- SRS tab -->
@@ -64,7 +64,7 @@
                 </TextBlock.Style>
             </TextBlock>
             <Button Grid.ColumnSpan="3" Style="{StaticResource NavigationPanelButton}" Command="{Binding NavigateCommand}"
-                    CommandParameter="{x:Static models:NavigationPageEnum.Srs}" />
+                    CommandParameter="{x:Static models:NavigationPageEnum.Srs}" ToolTip="(CTRL+2)" />
         </Grid>
 
         <!-- Kanji tab -->
@@ -76,7 +76,7 @@
             </Grid.ColumnDefinitions>
             <Label Grid.Column="1" Style="{StaticResource NavigationPanelTabTitle}" Content="KANJI" />
             <Button Grid.ColumnSpan="3" Style="{StaticResource NavigationPanelButton}" Command="{Binding NavigateCommand}"
-                    CommandParameter="{x:Static models:NavigationPageEnum.Kanji}" />
+                    CommandParameter="{x:Static models:NavigationPageEnum.Kanji}" ToolTip="(CTRL+3)" />
         </Grid>
 
         <!-- Vocab tab -->
@@ -88,7 +88,7 @@
             </Grid.ColumnDefinitions>
             <Label Grid.Column="1" Style="{StaticResource NavigationPanelTabTitle}" Content="VOCAB" />
             <Button Grid.ColumnSpan="3" Style="{StaticResource NavigationPanelButton}" Command="{Binding NavigateCommand}"
-                    CommandParameter="{x:Static models:NavigationPageEnum.Vocab}" />
+                    CommandParameter="{x:Static models:NavigationPageEnum.Vocab}" ToolTip="(CTRL+4)" />
         </Grid>
 
         <!-- Settings tab -->
@@ -113,7 +113,7 @@
                 </TextBlock.Style>
             </TextBlock>
             <Button Grid.ColumnSpan="3" Style="{StaticResource NavigationPanelButton}" Command="{Binding NavigateCommand}"
-                    CommandParameter="{x:Static models:NavigationPageEnum.Settings}" />
+                    CommandParameter="{x:Static models:NavigationPageEnum.Settings}" ToolTip="(CTRL+5)" />
         </Grid>
     </Grid>
 </UserControl>

--- a/Kanji.Interface/Views/Partial/ItemList/ListInfoHeaderControl.xaml
+++ b/Kanji.Interface/Views/Partial/ItemList/ListInfoHeaderControl.xaml
@@ -36,6 +36,7 @@
                         <MultiDataTrigger.Conditions>
                             <Condition Binding="{Binding LoadedItems.Count}" Value="0" />
                             <Condition Binding="{Binding TotalItemCount}" Value="0" />
+                            <Condition Binding="{Binding IsFiltering}" Value="True" />
                         </MultiDataTrigger.Conditions>
                         <Setter Property="Text" Value="There are no results for this request." />
                     </MultiDataTrigger>

--- a/Kanji.Interface/Views/Partial/Kanji/KanjiDetails.xaml
+++ b/Kanji.Interface/Views/Partial/Kanji/KanjiDetails.xaml
@@ -7,7 +7,7 @@
       xmlns:controls="clr-namespace:Kanji.Interface.Controls"
       xmlns:svgc="http://sharpvectors.codeplex.com/svgc/"
       xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
-      mc:Ignorable="d" 
+      mc:Ignorable="d" KeyDown="OnKeyDown"
       d:DesignHeight="300" d:DesignWidth="600">
     
     <Grid>
@@ -306,7 +306,7 @@
             <Separator Grid.Row="1" Margin="5,10" Height="2" Background="Black" Foreground="Black" BorderBrush="Black" />
             
             <!-- Reading filter -->
-            <controls:VocabFilterControl Grid.Row="2" DataContext="{Binding VocabFilterVm}" />
+            <controls:VocabFilterControl x:Name="VocabFilter" Grid.Row="2" DataContext="{Binding VocabFilterVm}" />
         </Grid>
 
         <!-- Vocab table -->

--- a/Kanji.Interface/Views/Partial/Kanji/KanjiDetails.xaml.cs
+++ b/Kanji.Interface/Views/Partial/Kanji/KanjiDetails.xaml.cs
@@ -17,9 +17,32 @@ namespace Kanji.Interface.Controls
 {
     public partial class KanjiDetails : UserControl
     {
+        #region Constructors
+
         public KanjiDetails()
         {
             InitializeComponent();
         }
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        /// Since a <see cref="GalaSoft.MvvmLight.Command.RelayCommand"/> does not accept keyboard shortcuts,
+        /// we have to manually invoke the commands on a keyboard event.
+        /// </summary>
+        private void OnKeyDown(object sender, KeyEventArgs e)
+        {
+            switch (e.Key)
+            {
+                case Key.Enter:
+                    VocabFilter.ApplyFilterButton.Command.Execute(null);
+                    e.Handled = true;
+                    break;
+            }
+        }
+
+        #endregion
     }
 }

--- a/Kanji.Interface/Views/Partial/Kanji/KanjiDetails.xaml.cs
+++ b/Kanji.Interface/Views/Partial/Kanji/KanjiDetails.xaml.cs
@@ -34,6 +34,39 @@ namespace Kanji.Interface.Controls
         /// </summary>
         private void OnKeyDown(object sender, KeyEventArgs e)
         {
+            KeyboardDevice keyboardDevice = e.KeyboardDevice;
+
+            if (keyboardDevice.IsKeyDown(Key.LeftCtrl) || keyboardDevice.IsKeyDown(Key.RightCtrl))
+            {
+                switch (e.Key)
+                {
+                    case Key.R:
+                        VocabFilter.ReadingFilter.Focus();
+                        e.Handled = true;
+                        break;
+                    case Key.M:
+                        VocabFilter.MeaningFilter.Focus();
+                        e.Handled = true;
+                        break;
+                    case Key.W:
+                        VocabFilter.WkLevelFilter.LevelSlider.Focus();
+                        e.Handled = true;
+                        break;
+                    case Key.J:
+                        VocabFilter.JlptLevelFilter.LevelSlider.Focus();
+                        e.Handled = true;
+                        break;
+                    case Key.C:
+                        // We can't just use CTRL+C here, because that would not work if a text box had focus.
+                        if (keyboardDevice.IsKeyDown(Key.LeftAlt) || keyboardDevice.IsKeyDown(Key.RightAlt))
+                        {
+                            VocabFilter.CategoryFilter.ComboBox.Focus();
+                            e.Handled = true;
+                        }
+                        break;
+                }
+            }
+
             switch (e.Key)
             {
                 case Key.Enter:

--- a/Kanji.Interface/Views/Partial/Kanji/KanjiFilterControl.xaml
+++ b/Kanji.Interface/Views/Partial/Kanji/KanjiFilterControl.xaml
@@ -28,8 +28,9 @@
         
         <!-- 0. Multiline text filter -->
         <AdornerDecorator Grid.ColumnSpan="4">
-            <controls:CommandTextBox TextWrapping="Wrap" AcceptsReturn="False" Height="45" Margin="0 0 0 5"
+            <controls:CommandTextBox x:Name="TextFilter" TextWrapping="Wrap" AcceptsReturn="False" Height="45" Margin="0 0 0 5"
                 Text="{Binding TextFilter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                ToolTip="Shortcut: (CTRL+T)."
                 ValidationCommand="{Binding SendTextFilterCommand}">
                 <controls:WatermarkService.Watermark>
                     <TextBlock TextAlignment="Center" VerticalAlignment="Center">
@@ -43,7 +44,8 @@
         <!-- 1. Reading/meaning filter -->
         <TextBlock Grid.Row="1" Text="with" Margin="0 0 5 0" VerticalAlignment="Center" />
         <AdornerDecorator Grid.Row="1" Grid.Column="1">
-            <controls:CommandTextBox Text="{Binding MainFilter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+            <controls:CommandTextBox x:Name="Filter" Text="{Binding MainFilter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                ToolTip="Shortcut: (CTRL+F)."
                 ValidationCommand="{Binding SendMainFilterCommand}">
                 <controls:WatermarkService.Watermark>
                     <TextBlock TextAlignment="Center" VerticalAlignment="Center">
@@ -74,8 +76,8 @@
                 <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
-            <controls:WkLevelFilterControl Grid.Column="0" DataContext="{Binding}" />
-            <controls:JlptLevelFilterControl Grid.Column="1" Margin="5,0,0,0" DataContext="{Binding}" />
+            <controls:WkLevelFilterControl x:Name="WkLevelFilter" Grid.Column="0" DataContext="{Binding}" />
+            <controls:JlptLevelFilterControl x:Name="JlptLevelFilter" Grid.Column="1" Margin="5,0,0,0" DataContext="{Binding}" />
         </Grid>
 
         <!-- 2. Radical list label -->
@@ -93,8 +95,8 @@
                 <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
             <AdornerDecorator>
-                <TextBox Text="{Binding RadicalFilter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                    ToolTip="Type the filter until one single result remains, then press Enter to select it.">
+                <TextBox x:Name="RadicalNameFilter" Text="{Binding RadicalFilter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                    ToolTip="Type the filter until one single result remains, then press Enter to select or deselect it (CTRL+R).">
                     <TextBox.InputBindings>
                         <KeyBinding Command="{Binding SendRadicalFilterCommand}" Key="Enter" />
                     </TextBox.InputBindings>

--- a/Kanji.Interface/Views/Partial/Kanji/KanjiFilterControl.xaml
+++ b/Kanji.Interface/Views/Partial/Kanji/KanjiFilterControl.xaml
@@ -30,8 +30,7 @@
         <AdornerDecorator Grid.ColumnSpan="4">
             <controls:CommandTextBox x:Name="TextFilter" TextWrapping="Wrap" AcceptsReturn="False" Height="45" Margin="0 0 0 5"
                 Text="{Binding TextFilter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                ToolTip="Shortcut: (CTRL+T)."
-                ValidationCommand="{Binding SendTextFilterCommand}">
+                ToolTip="Shortcut: (CTRL+T).">
                 <controls:WatermarkService.Watermark>
                     <TextBlock TextAlignment="Center" VerticalAlignment="Center">
                         Enter the kanji or a text containing kanji you are looking for.<LineBreak />
@@ -45,8 +44,7 @@
         <TextBlock Grid.Row="1" Text="with" Margin="0 0 5 0" VerticalAlignment="Center" />
         <AdornerDecorator Grid.Row="1" Grid.Column="1">
             <controls:CommandTextBox x:Name="Filter" Text="{Binding MainFilter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                ToolTip="Shortcut: (CTRL+F)."
-                ValidationCommand="{Binding SendMainFilterCommand}">
+                ToolTip="Shortcut: (CTRL+F).">
                 <controls:WatermarkService.Watermark>
                     <TextBlock TextAlignment="Center" VerticalAlignment="Center">
                         <TextBlock.Text>
@@ -91,6 +89,7 @@
         <Grid Grid.Row="5" Grid.ColumnSpan="4" Margin="0 5">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>

--- a/Kanji.Interface/Views/Partial/Kanji/KanjiFilterControl.xaml
+++ b/Kanji.Interface/Views/Partial/Kanji/KanjiFilterControl.xaml
@@ -54,6 +54,27 @@
                         </TextBlock.Text>
                     </TextBlock>
                 </controls:WatermarkService.Watermark>
+                <controls:CommandTextBox.Style>
+                    <Style TargetType="controls:CommandTextBox">
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding MainFilterMode, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" Value="{x:Static models:KanjiFilterModeEnum.Meaning}">
+                                <Setter Property="IsKanaInput" Value="False" />
+                            </DataTrigger>
+                            <DataTrigger Binding="{Binding MainFilterMode, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" Value="{x:Static models:KanjiFilterModeEnum.AnyReading}">
+                                <Setter Property="IsKanaInput" Value="True" />
+                            </DataTrigger>
+                            <DataTrigger Binding="{Binding MainFilterMode, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" Value="{x:Static models:KanjiFilterModeEnum.KunYomi}">
+                                <Setter Property="IsKanaInput" Value="True" />
+                            </DataTrigger>
+                            <DataTrigger Binding="{Binding MainFilterMode, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" Value="{x:Static models:KanjiFilterModeEnum.OnYomi}">
+                                <Setter Property="IsKanaInput" Value="True" />
+                            </DataTrigger>
+                            <DataTrigger Binding="{Binding MainFilterMode, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" Value="{x:Static models:KanjiFilterModeEnum.Nanori}">
+                                <Setter Property="IsKanaInput" Value="True" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </controls:CommandTextBox.Style>
             </controls:CommandTextBox>
         </AdornerDecorator>
         <TextBlock Grid.Row="1" Grid.Column="2" Text="as" VerticalAlignment="Center" Margin="5,0" />

--- a/Kanji.Interface/Views/Partial/Srs/DashboardReviewCountControl.xaml
+++ b/Kanji.Interface/Views/Partial/Srs/DashboardReviewCountControl.xaml
@@ -90,7 +90,7 @@
                 </Grid>
 
                 <!-- Start review button -->
-                <Button Grid.Row="1" Grid.Column="1" Content="Start reviewing" Height="34"
+                <Button Grid.Row="1" Grid.Column="1" Content="Start reviewing" ToolTip="(CTRL+Enter)" Height="34"
                     Command="{Binding StartReviewsCommand}">
                     <Button.Style>
                         <Style TargetType="Button" BasedOn="{StaticResource BrightActionButton}">

--- a/Kanji.Interface/Views/Partial/Srs/Filters/SrsEntryMeaningFilterControl.xaml
+++ b/Kanji.Interface/Views/Partial/Srs/Filters/SrsEntryMeaningFilterControl.xaml
@@ -20,7 +20,7 @@
                         VerticalAlignment="Center" Margin="0 0 5 0" />
 
                     <AdornerDecorator Grid.Column="1">
-                        <controls:CommandTextBox MaxLength="100" ToolTip="Enter the meaning filter."
+                        <controls:CommandTextBox x:Name="FilterTextBox" MaxLength="100" ToolTip="Enter the meaning filter. (CTRL+M)"
                             Text="{Binding MeaningFilter, UpdateSourceTrigger=PropertyChanged}"
                             ValidationCommand="{Binding ValidateCommand}">
                             <controls:WatermarkService.Watermark>
@@ -52,7 +52,7 @@
                             <TextBlock Text="Containing the meaning:" Style="{StaticResource LegendText}" />
                             <StackPanel Grid.Row="1">
                                 <AdornerDecorator>
-                                    <controls:CommandTextBox MaxLength="100" ToolTip="Enter the meaning filter."
+                                    <controls:CommandTextBox x:Name="FilterTextBox" MaxLength="100" ToolTip="Enter the meaning filter. (CTRL+M)"
                                     Text="{Binding MeaningFilter, UpdateSourceTrigger=PropertyChanged}"
                                     ValidationCommand="{Binding ValidateCommand}">
                                         <controls:WatermarkService.Watermark>

--- a/Kanji.Interface/Views/Partial/Srs/Filters/SrsEntryReadingFilterControl.xaml
+++ b/Kanji.Interface/Views/Partial/Srs/Filters/SrsEntryReadingFilterControl.xaml
@@ -20,7 +20,7 @@
                         VerticalAlignment="Center" Margin="0 0 5 0" />
 
                     <AdornerDecorator Grid.Column="1">
-                        <controls:CommandTextBox MaxLength="100" ToolTip="Enter the reading filter."
+                        <controls:CommandTextBox x:Name="FilterTextBox" MaxLength="100" ToolTip="Enter the reading filter. (CTRL+R)"
                             Text="{Binding ReadingFilter, UpdateSourceTrigger=PropertyChanged}"
                             ValidationCommand="{Binding ValidateCommand}">
                             <controls:WatermarkService.Watermark>
@@ -52,7 +52,7 @@
 
                             <StackPanel Grid.Row="1">
                                 <AdornerDecorator>
-                                    <controls:CommandTextBox MaxLength="100" ToolTip="Enter the reading filter."
+                                    <controls:CommandTextBox x:Name="FilterTextBox" MaxLength="100" ToolTip="Enter the reading filter."
                                         Text="{Binding ReadingFilter, UpdateSourceTrigger=PropertyChanged}"
                                         ValidationCommand="{Binding ValidateCommand}">
                                         <controls:WatermarkService.Watermark>

--- a/Kanji.Interface/Views/Partial/Srs/Filters/SrsEntryTagsFilterControl.xaml
+++ b/Kanji.Interface/Views/Partial/Srs/Filters/SrsEntryTagsFilterControl.xaml
@@ -23,7 +23,7 @@
                         VerticalAlignment="Center" Margin="0 0 5 0" />
 
                     <AdornerDecorator Grid.Column="1">
-                        <controls:CommandTextBox MaxLength="100" ToolTip="Enter the tag filter."
+                        <controls:CommandTextBox x:Name="FilterTextBox" MaxLength="100" ToolTip="Enter the tag filter. (CTRL+T)"
                             Text="{Binding TagFilter, UpdateSourceTrigger=PropertyChanged}"
                             ValidationCommand="{Binding ValidateCommand}">
                             <controls:WatermarkService.Watermark>
@@ -65,7 +65,7 @@
 
                             <StackPanel Grid.Row="1">
                                 <AdornerDecorator>
-                                    <controls:CommandTextBox MaxLength="100" ToolTip="Enter the tag filter."
+                                    <controls:CommandTextBox x:Name="FilterTextBox" MaxLength="100" ToolTip="Enter the tag filter."
                                     Text="{Binding TagFilter, UpdateSourceTrigger=PropertyChanged}"
                                     ValidationCommand="{Binding ValidateCommand}">
                                         <controls:WatermarkService.Watermark>

--- a/Kanji.Interface/Views/Partial/Srs/Filters/SrsEntryTypeFilterControl.xaml
+++ b/Kanji.Interface/Views/Partial/Srs/Filters/SrsEntryTypeFilterControl.xaml
@@ -24,12 +24,12 @@
                                     <CheckBox Content="Kanji items" HorizontalAlignment="Center"
                                         IsChecked="{Binding IsKanjiItemEnabled}"
                                         Command="{Binding FilterChangedCommand}"
-                                        ToolTip="Include kanji items" />
+                                        ToolTip="Include kanji items (CTRL+Alt+K)" />
                                     <CheckBox Grid.Column="1" Content="Vocab items"
                                         HorizontalAlignment="Center"
                                         IsChecked="{Binding IsVocabItemEnabled}"
                                         Command="{Binding FilterChangedCommand}"
-                                        ToolTip="Include vocab items" />
+                                        ToolTip="Include vocab items (CTRL+Alt+V)" />
                                 </Grid>
                             </ControlTemplate>
                         </Setter.Value>
@@ -58,12 +58,12 @@
                             <CheckBox Grid.Row="1" HorizontalAlignment="Center"
                                 IsChecked="{Binding IsKanjiItemEnabled}"
                                 Command="{Binding FilterChangedCommand}"
-                                ToolTip="Include kanji items" />
+                                ToolTip="Include kanji items (CTRL+Alt+K)" />
                             <CheckBox Grid.Row="1" Grid.Column="1"
                                 HorizontalAlignment="Center"
                                 IsChecked="{Binding IsVocabItemEnabled}"
                                 Command="{Binding FilterChangedCommand}"
-                                ToolTip="Include vocab items" />
+                                ToolTip="Include vocab items (CTRL+Alt+V)" />
                         </Grid>
                     </ControlTemplate>
                 </Setter.Value>

--- a/Kanji.Interface/Views/Partial/Srs/SrsEntryFilterControl.xaml
+++ b/Kanji.Interface/Views/Partial/Srs/SrsEntryFilterControl.xaml
@@ -22,25 +22,27 @@
         </Grid.ColumnDefinitions>
         
         <Button Style="{StaticResource ActionButton}" Content="Browse all items" Margin="0 0 0 5"
-                Command="{Binding BrowseAllItemsCommand}" />
+                Command="{Binding BrowseAllItemsCommand}"
+                ToolTip="(CTRL+Alt+A)" />
 
         <Button Style="{StaticResource ActionButton}" Grid.Row="0" Grid.Column="3" Content="Refresh"
-                Margin="0 0 0 5" Command="{Binding RefreshCommand}" />
+                Margin="0 0 0 5" Command="{Binding RefreshCommand}"
+                ToolTip="Refreshes the current view with the latest data from the database (F5)" />
 
-        <controls:SrsEntryMeaningFilterControl Grid.Row="1" Grid.Column="0" DataContext="{Binding MeaningFilterVm}"
+        <controls:SrsEntryMeaningFilterControl x:Name="MeaningFilter" Grid.Row="1" Grid.Column="0" DataContext="{Binding MeaningFilterVm}"
             IsInline="False" Margin="0 0 5 0" />
-        <controls:SrsEntryReadingFilterControl Grid.Row="1" Grid.Column="1" DataContext="{Binding ReadingFilterVm}"
+        <controls:SrsEntryReadingFilterControl x:Name="ReadingFilter" Grid.Row="1" Grid.Column="1" DataContext="{Binding ReadingFilterVm}"
             IsInline="False" Margin="0 0 5 0" />
-        <controls:SrsEntryTagsFilterControl Grid.Row="1" Grid.Column="2" DataContext="{Binding TagsFilterVm}"
+        <controls:SrsEntryTagsFilterControl x:Name="TagFilter" Grid.Row="1" Grid.Column="2" DataContext="{Binding TagsFilterVm}"
             IsInline="False" Margin="0 0 5 0" />
         <controls:SrsEntryTypeFilterControl Grid.Row="1" Grid.Column="3" DataContext="{Binding TypeFilterVm}"
             IsInline="False" />
         
-        <controls:SrsEntryLevelFilterControl Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="3" DataContext="{Binding LevelFilterVm}" />
+        <controls:SrsEntryLevelFilterControl Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="4" DataContext="{Binding LevelFilterVm}" />
 
-        <TextBlock Grid.Row="2" Grid.Column="3" Text="Category" Style="{StaticResource LegendText}" VerticalAlignment="Center" />
+        <!--<TextBlock Grid.Row="2" Grid.Column="3" Text="Category" Style="{StaticResource LegendText}" VerticalAlignment="Center" />
         
-        <!--<controls:SrsEntryCategoryFilterControl Grid.Row="2" Grid.Column="3" Margin="50,0,0,0" DataContext="{Binding CategoryFilterVm}" />
+        <controls:SrsEntryCategoryFilterControl Grid.Row="2" Grid.Column="3" Margin="50,0,0,0" DataContext="{Binding CategoryFilterVm}" />
 
         <controls:SrsEntryWkLevelFilterControl Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="3" DataContext="{Binding WkLevelFilterVm}" />
         <controls:SrsEntryJlptLevelFilterControl Grid.Row="3" Grid.Column="3" DataContext="{Binding JlptLevelFilterVm}" />-->

--- a/Kanji.Interface/Views/Partial/Srs/SrsPageNavigationControl.xaml
+++ b/Kanji.Interface/Views/Partial/Srs/SrsPageNavigationControl.xaml
@@ -7,13 +7,13 @@
              d:DesignHeight="50" d:DesignWidth="500">
 
     <UniformGrid Rows="1">
-        <Button Content="Add a kanji item" ToolTip="Add a new kanji SRS item to your list"
+        <Button Content="Add a kanji item" ToolTip="Add a new kanji SRS item to your list (CTRL+K)"
             Margin="0 0 5 0" Command="{Binding AddKanjiItemCommand}" Style="{StaticResource ActionButton}" />
-        <Button Content="Add a vocab item" ToolTip="Add a new vocab SRS item to your list"
+        <Button Content="Add a vocab item" ToolTip="Add a new vocab SRS item to your list (CTRL+V)"
             Margin="0 0 5 0" Command="{Binding AddVocabItemCommand}" Style="{StaticResource ActionButton}" />
-        <Button Content="Import SRS items" ToolTip="Import SRS items from external sources (Anki, WaniKani, etc)"
+        <Button Content="Import SRS items" ToolTip="Import SRS items from external sources (Anki, WaniKani, etc) (CTRL+I)"
             Margin="0 0 5 0" Command="{Binding ImportCommand}" Style="{StaticResource ActionButton}" />
-        <Button Content="Dashboard" ToolTip="Return to the dashboard"
+        <Button Content="Dashboard" ToolTip="Return to the dashboard (CTRL+Alt+Home)"
             Margin="0 0 5 0" Command="{Binding SwitchToDashboardCommand}">
             <Button.Style>
                 <Style TargetType="Button" BasedOn="{StaticResource ActionButton}">
@@ -25,7 +25,7 @@
                 </Style>
             </Button.Style>
         </Button>
-        <Button Content="Browse SRS items" ToolTip="Display the SRS item filter panel"
+        <Button Content="Browse SRS items" ToolTip="Display the SRS item filter panel (CTRL+B)"
             Grid.Column="1" Command="{Binding SwitchToSimpleFilterCommand}">
             <Button.Style>
                 <Style TargetType="Button" BasedOn="{StaticResource ActionButton}">

--- a/Kanji.Interface/Views/Partial/Srs/SrsReviewControl.xaml
+++ b/Kanji.Interface/Views/Partial/Srs/SrsReviewControl.xaml
@@ -324,7 +324,7 @@
                 </Border.Style>
                 <StackPanel Orientation="Vertical">
                     <Button Style="{StaticResource VocabAudioButton}" Width="120" HorizontalAlignment="Left"
-                        BorderBrush="Black" DataContext="{Binding CurrentQuestion.ParentGroup.Audio}"
+                        BorderBrush="Black"
                         Visibility="{Binding CurrentQuestion.ParentGroup.IsVocab, Converter={StaticResource ValueToVisibilityConverter}}" />
                     <TextBlock Style="{StaticResource LegendText}" Text="Reading notes:" />
                     <TextBlock Text="{Binding CurrentQuestion.ParentGroup.Reference.ReadingNote, Mode=OneWay}" TextWrapping="Wrap" />

--- a/Kanji.Interface/Views/Partial/Srs/SrsReviewControl.xaml
+++ b/Kanji.Interface/Views/Partial/Srs/SrsReviewControl.xaml
@@ -35,23 +35,35 @@
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 
-        <!-- Exit button -->
-        <Button Command="{Binding WrapUpCommand}">
-            <Button.Style>
-                <Style TargetType="Button" BasedOn="{StaticResource MiniActionButton}">
-                    <Style.Triggers>
-                        <DataTrigger Binding="{Binding IsWrappingUp}" Value="True">
-                            <Setter Property="IsEnabled" Value="False" />
-                        </DataTrigger>
-                        <DataTrigger Binding="{Binding IsWrappingUp}" Value="True">
-                            <Setter Property="Content" Value="Finishing the current batch of review items..." />
-                        </DataTrigger>
-                    </Style.Triggers>
-                    <Setter Property="Content" Value="Wrap up" />
-                    <Setter Property="ToolTip" Value="Wraps up this review session. Shortcut if enabled: (CTRL+W)." />
-                </Style>
-            </Button.Style>
-        </Button>
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="30"/>
+            </Grid.ColumnDefinitions>
+            
+            <!-- Wrap Up button -->
+            <Button Command="{Binding WrapUpCommand}">
+                <Button.Style>
+                    <Style TargetType="Button" BasedOn="{StaticResource MiniActionButton}">
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding IsWrappingUp}" Value="True">
+                                <Setter Property="IsEnabled" Value="False" />
+                            </DataTrigger>
+                            <DataTrigger Binding="{Binding IsWrappingUp}" Value="True">
+                                <Setter Property="Content" Value="Finishing the current batch of review items..." />
+                            </DataTrigger>
+                        </Style.Triggers>
+                        <Setter Property="Content" Value="Wrap up" />
+                        <Setter Property="ToolTip" Value="Wraps up this review session. Shortcut if enabled: (CTRL+W)." />
+                    </Style>
+                </Button.Style>
+            </Button>
+
+            <!-- Exit without wrapping up button -->
+            <Button Grid.Column="1" Command="{Binding StopSessionCommand}"
+                    Content="X" ToolTip="Exits this review session immediately. Some data may be lost."
+                    Style="{StaticResource MiniActionButton}" />
+        </Grid>
 
         <Border Grid.Row="1">
             <ProgressBar Style="{StaticResource SrsReviewProgressBar}"

--- a/Kanji.Interface/Views/Partial/Srs/SrsReviewControl.xaml
+++ b/Kanji.Interface/Views/Partial/Srs/SrsReviewControl.xaml
@@ -324,7 +324,7 @@
                 </Border.Style>
                 <StackPanel Orientation="Vertical">
                     <Button Style="{StaticResource VocabAudioButton}" Width="120" HorizontalAlignment="Left"
-                        BorderBrush="Black"
+                        BorderBrush="Black" DataContext="{Binding CurrentQuestion.ParentGroup.Audio}"
                         Visibility="{Binding CurrentQuestion.ParentGroup.IsVocab, Converter={StaticResource ValueToVisibilityConverter}}" />
                     <TextBlock Style="{StaticResource LegendText}" Text="Reading notes:" />
                     <TextBlock Text="{Binding CurrentQuestion.ParentGroup.Reference.ReadingNote, Mode=OneWay}" TextWrapping="Wrap" />

--- a/Kanji.Interface/Views/Partial/Srs/SrsReviewControl.xaml
+++ b/Kanji.Interface/Views/Partial/Srs/SrsReviewControl.xaml
@@ -36,10 +36,22 @@
         </Grid.RowDefinitions>
 
         <!-- Exit button -->
-        <Button Style="{StaticResource MiniActionButton}"
-                        Content="Close review session"
-                        ToolTip="Close this SRS review session. Some progress may be lost."
-                        Command="{Binding StopSessionCommand}" />
+        <Button Command="{Binding WrapUpCommand}">
+            <Button.Style>
+                <Style TargetType="Button" BasedOn="{StaticResource MiniActionButton}">
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding IsWrappingUp}" Value="True">
+                            <Setter Property="IsEnabled" Value="False" />
+                        </DataTrigger>
+                        <DataTrigger Binding="{Binding IsWrappingUp}" Value="True">
+                            <Setter Property="Content" Value="Finishing the current batch of review items..." />
+                        </DataTrigger>
+                    </Style.Triggers>
+                    <Setter Property="Content" Value="Wrap up" />
+                    <Setter Property="ToolTip" Value="Wraps up this review session. Shortcut if enabled: (CTRL+W)." />
+                </Style>
+            </Button.Style>
+        </Button>
 
         <Border Grid.Row="1">
             <ProgressBar Style="{StaticResource SrsReviewProgressBar}"
@@ -313,10 +325,9 @@
                     <ColumnDefinition Width="*" />
                     <ColumnDefinition Width="*" />
                     <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="*" />
                 </Grid.ColumnDefinitions>
 
-                <Button Grid.Column="1" Content="Ignore answer"
+                <Button Grid.Column="0" Content="Ignore answer"
                         ToolTip="Use this button to ignore the answer you gave. The question will come back later. Shortcut if enabled: (Backspace)"
                         Command="{Binding IgnoreAnswerCommand}" Margin="5 0">
                     <Button.Style>
@@ -330,7 +341,7 @@
                     </Button.Style>
                 </Button>
 
-                <Button Grid.Column="2" Command="{Binding AddAnswerCommand}" Margin="5 0">
+                <Button Grid.Column="1" Command="{Binding AddAnswerCommand}" Margin="5 0">
                     <Button.Style>
                         <Style TargetType="Button" BasedOn="{StaticResource ActionButton}">
                             <Style.Triggers>
@@ -349,7 +360,7 @@
                     </Button.Style>
                 </Button>
 
-                <Button Grid.Column="3" Content="Edit this item"
+                <Button Grid.Column="2" Content="Edit this item"
                         ToolTip="Open the item edition window. Does not change your answer or its effects."
                         Command="{Binding EditSrsEntryCommand}" Margin="5 0">
                     <Button.Style>
@@ -363,50 +374,6 @@
                     </Button.Style>
                 </Button>
 
-            </Grid>
-
-        </Grid>
-
-        <!-- Tool buttons (displayed always) -->
-        <Grid Grid.Row="5">
-            <!--
-                Using the same row/column layout as the grid that is hidden during answering
-                so that it's easy to add other stuff that is always visible in the future.
-            -->
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="*" />
-                <RowDefinition Height="Auto" />
-            </Grid.RowDefinitions>
-            
-            <!-- Action buttons -->
-            <Grid Grid.Row="2">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="*" />
-                </Grid.ColumnDefinitions>
-
-                <Button Command="{Binding WrapUpCommand}" Margin="5 0">
-                    <Button.Style>
-                        <Style TargetType="Button" BasedOn="{StaticResource ActionButton}">
-                            <Style.Triggers>
-                                <DataTrigger Binding="{Binding IsWrappingUp}" Value="True">
-                                    <Setter Property="IsEnabled" Value="False" />
-                                </DataTrigger>
-                                <DataTrigger Binding="{Binding IsWrappingUp}" Value="True">
-                                    <Setter Property="Content" Value="Wrapping up..." />
-                                </DataTrigger>
-                            </Style.Triggers>
-                            <Setter Property="Content" Value="Wrap up" />
-                            <Setter Property="ToolTip" Value="Wraps up this review session. Shortcut if enabled: (CTRL+W)." />
-                        </Style>
-                    </Button.Style>
-                </Button>
             </Grid>
         </Grid>
     </Grid>

--- a/Kanji.Interface/Views/Partial/Srs/SrsReviewControl.xaml
+++ b/Kanji.Interface/Views/Partial/Srs/SrsReviewControl.xaml
@@ -22,6 +22,7 @@
         <KeyBinding Key="Back" Command="{Binding IgnoreAnswerShortcutCommand}" />
         <KeyBinding Key="OemPlus" Command="{Binding AddAnswerShortcutCommand}" />
         <KeyBinding Key="Add" Command="{Binding AddAnswerShortcutCommand}" />
+        <KeyBinding Key="W" Modifiers="Control" Command="{Binding WrapUpCommand}" />
     </UserControl.InputBindings>
 
     <Grid>
@@ -312,10 +313,11 @@
                     <ColumnDefinition Width="*" />
                     <ColumnDefinition Width="*" />
                     <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
                 </Grid.ColumnDefinitions>
 
-                <Button Content="Ignore answer"
-                        ToolTip="Use this button to ignore the answer you gave. The question will come back later."
+                <Button Grid.Column="1" Content="Ignore answer"
+                        ToolTip="Use this button to ignore the answer you gave. The question will come back later. Shortcut if enabled: (Backspace)"
                         Command="{Binding IgnoreAnswerCommand}" Margin="5 0">
                     <Button.Style>
                         <Style TargetType="Button" BasedOn="{StaticResource ActionButton}">
@@ -328,7 +330,7 @@
                     </Button.Style>
                 </Button>
 
-                <Button Grid.Column="1" Command="{Binding AddAnswerCommand}" Margin="5 0">
+                <Button Grid.Column="2" Command="{Binding AddAnswerCommand}" Margin="5 0">
                     <Button.Style>
                         <Style TargetType="Button" BasedOn="{StaticResource ActionButton}">
                             <Style.Triggers>
@@ -342,12 +344,12 @@
                             </Style.Triggers>
                             <Setter Property="Visibility" Value="Collapsed" />
                             <Setter Property="Content" Value="Add to readings" />
-                            <Setter Property="ToolTip" Value="Mark your answer as correct and add the answer as a correct reading." />
+                            <Setter Property="ToolTip" Value="Mark your answer as correct and add the answer as a correct reading. Shortcut if enabled: (+)" />
                         </Style>
                     </Button.Style>
                 </Button>
 
-                <Button Grid.Column="2" Content="Edit this item"
+                <Button Grid.Column="3" Content="Edit this item"
                         ToolTip="Open the item edition window. Does not change your answer or its effects."
                         Command="{Binding EditSrsEntryCommand}" Margin="5 0">
                     <Button.Style>
@@ -364,6 +366,48 @@
             </Grid>
 
         </Grid>
-        
+
+        <!-- Tool buttons (displayed always) -->
+        <Grid Grid.Row="5">
+            <!--
+                Using the same row/column layout as the grid that is hidden during answering
+                so that it's easy to add other stuff that is always visible in the future.
+            -->
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+            
+            <!-- Action buttons -->
+            <Grid Grid.Row="2">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+
+                <Button Command="{Binding WrapUpCommand}" Margin="5 0">
+                    <Button.Style>
+                        <Style TargetType="Button" BasedOn="{StaticResource ActionButton}">
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding IsWrappingUp}" Value="True">
+                                    <Setter Property="IsEnabled" Value="False" />
+                                </DataTrigger>
+                                <DataTrigger Binding="{Binding IsWrappingUp}" Value="True">
+                                    <Setter Property="Content" Value="Wrapping up..." />
+                                </DataTrigger>
+                            </Style.Triggers>
+                            <Setter Property="Content" Value="Wrap up" />
+                            <Setter Property="ToolTip" Value="Wraps up this review session. Shortcut if enabled: (CTRL+W)." />
+                        </Style>
+                    </Button.Style>
+                </Button>
+            </Grid>
+        </Grid>
     </Grid>
 </UserControl>

--- a/Kanji.Interface/Views/Partial/Vocab/VocabFilterControl.xaml
+++ b/Kanji.Interface/Views/Partial/Vocab/VocabFilterControl.xaml
@@ -22,7 +22,7 @@
         <!-- Reading filter -->
         <AdornerDecorator>
             <controls:CommandTextBox x:Name="ReadingFilter" Text="{Binding ReadingFilter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                ValidationCommand="{Binding SendReadingFilterCommand}" IsKanaInput="True" Margin="0 0 5 0"
+                IsKanaInput="True" Margin="0 0 5 0"
                 ToolTip="Enter the kana reading to filter by here (CTRL+R)."
                 VerticalContentAlignment="Center">
                 <controls:WatermarkService.Watermark>
@@ -36,7 +36,7 @@
         <!-- Meaning filter -->
         <AdornerDecorator Grid.Row="0" Grid.Column="1">
             <controls:CommandTextBox x:Name="MeaningFilter" Text="{Binding MeaningFilter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                ValidationCommand="{Binding SendMeaningFilterCommand}" Margin="5 0 0 0"
+                Margin="5 0 0 0"
                 ToolTip="Enter the English meaning to filter by here (CTRL+M)."
                 VerticalContentAlignment="Center">
                 <controls:WatermarkService.Watermark>
@@ -119,7 +119,10 @@
 
         <!-- JLPT/WK levels -->
         <controls:WkLevelFilterControl x:Name="WkLevelFilter" Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" DataContext="{Binding}" />
-        <controls:JlptLevelFilterControl x:Name="JlptLevelFilter" Grid.Row="1" Grid.Column="2" Grid.ColumnSpan="2" Margin="5,0,0,0" DataContext="{Binding}" />
+        <controls:JlptLevelFilterControl x:Name="JlptLevelFilter" Grid.Row="1" Grid.Column="2" Margin="5,0,0,0" DataContext="{Binding}" />
 
+        <Button x:Name="ApplyFilterButton" Style="{StaticResource MiniActionButton}" Command="{Binding ApplyFilterCommand}"
+                Content="Apply Filter" ToolTip="(Enter)" Grid.Row="1" Grid.Column="3"
+                HorizontalAlignment="Stretch" VerticalAlignment="Stretch" />
     </Grid>
 </UserControl>

--- a/Kanji.Interface/Views/Partial/Vocab/VocabFilterControl.xaml
+++ b/Kanji.Interface/Views/Partial/Vocab/VocabFilterControl.xaml
@@ -21,8 +21,9 @@
 
         <!-- Reading filter -->
         <AdornerDecorator>
-            <controls:CommandTextBox Text="{Binding ReadingFilter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+            <controls:CommandTextBox x:Name="ReadingFilter" Text="{Binding ReadingFilter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                 ValidationCommand="{Binding SendReadingFilterCommand}" IsKanaInput="True" Margin="0 0 5 0"
+                ToolTip="Enter the kana reading to filter by here (CTRL+R)."
                 VerticalContentAlignment="Center">
                 <controls:WatermarkService.Watermark>
                     <TextBlock HorizontalAlignment="Center" VerticalAlignment="Center">
@@ -34,8 +35,9 @@
 
         <!-- Meaning filter -->
         <AdornerDecorator Grid.Row="0" Grid.Column="1">
-            <controls:CommandTextBox Text="{Binding MeaningFilter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+            <controls:CommandTextBox x:Name="MeaningFilter" Text="{Binding MeaningFilter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                 ValidationCommand="{Binding SendMeaningFilterCommand}" Margin="5 0 0 0"
+                ToolTip="Enter the English meaning to filter by here (CTRL+M)."
                 VerticalContentAlignment="Center">
                 <controls:WatermarkService.Watermark>
                     <TextBlock HorizontalAlignment="Center" VerticalAlignment="Center">
@@ -49,7 +51,7 @@
         <AdornerDecorator Grid.Row="0" Grid.Column="2" Margin="5,0,5,0">
             <Grid>
                 <TextBlock Text="Category Filter" Style="{StaticResource LegendText}" />
-                <controls:CategoryFilterControl Margin="80,0,0,0" DataContext="{Binding}" />
+                <controls:CategoryFilterControl x:Name="CategoryFilter" Margin="80,0,0,0" DataContext="{Binding}" />
             </Grid>
         </AdornerDecorator>
         
@@ -116,8 +118,8 @@
         </StackPanel>
 
         <!-- JLPT/WK levels -->
-        <controls:WkLevelFilterControl Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" DataContext="{Binding}" />
-        <controls:JlptLevelFilterControl Grid.Row="1" Grid.Column="2" Grid.ColumnSpan="2" Margin="5,0,0,0" DataContext="{Binding}" />
+        <controls:WkLevelFilterControl x:Name="WkLevelFilter" Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" DataContext="{Binding}" />
+        <controls:JlptLevelFilterControl x:Name="JlptLevelFilter" Grid.Row="1" Grid.Column="2" Grid.ColumnSpan="2" Margin="5,0,0,0" DataContext="{Binding}" />
 
     </Grid>
 </UserControl>

--- a/Kanji.Interface/Views/SettingsPage.xaml
+++ b/Kanji.Interface/Views/SettingsPage.xaml
@@ -5,8 +5,8 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:models="clr-namespace:Kanji.Interface.Models"
              xmlns:controls="clr-namespace:Kanji.Interface.Controls"
-             mc:Ignorable="d" 
-             d:DesignHeight="300" d:DesignWidth="600">
+             mc:Ignorable="d" Focusable="true"
+             d:DesignHeight="300" d:DesignWidth="600" KeyDown="OnKeyDown" IsVisibleChanged="OnIsVisibleChanged">
 
     <DockPanel>
         <controls:NavigationBar DockPanel.Dock="Top" />

--- a/Kanji.Interface/Views/SettingsPage.xaml.cs
+++ b/Kanji.Interface/Views/SettingsPage.xaml.cs
@@ -18,10 +18,45 @@ namespace Kanji.Interface.Views
 {
     public partial class SettingsPage : UserControl
     {
+        #region Constructors
+
         public SettingsPage()
         {
             InitializeComponent();
             DataContext = new SettingsViewModel();
         }
+
+        #endregion
+        
+        #region Methods
+        
+        /// <summary>
+        /// Since a <see cref="GalaSoft.MvvmLight.Command.RelayCommand"/> does not accept keyboard shortcuts,
+        /// we have to manually invoke the commands on a keyboard event.
+        /// </summary>
+        private void OnKeyDown(object sender, KeyEventArgs e)
+        {
+            KeyboardDevice keyboardDevice = e.KeyboardDevice;
+
+            if (keyboardDevice.IsKeyDown(Key.LeftCtrl) || keyboardDevice.IsKeyDown(Key.RightCtrl))
+            {
+                switch (e.Key)
+                {
+
+                }
+            }
+        }
+
+        private void OnIsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e)
+        {
+            // Focus the page once it becomes visible.
+            // This is so that the navigation bar does not keep the focus, which would prevent shortcut keys from working.
+            if (((bool)e.NewValue))
+            {
+                Focus();
+            }
+        }
+
+        #endregion
     }
 }

--- a/Kanji.Interface/Views/SrsPage.xaml
+++ b/Kanji.Interface/Views/SrsPage.xaml
@@ -9,8 +9,8 @@
       xmlns:controls="clr-namespace:Kanji.Interface.Controls"
       xmlns:business="clr-namespace:Kanji.Interface.Business"
       xmlns:converters="clr-namespace:Kanji.Interface.Converters"
-      mc:Ignorable="d" 
-      d:DesignHeight="300" d:DesignWidth="600">
+      mc:Ignorable="d" Focusable="true"
+      d:DesignHeight="300" d:DesignWidth="600" KeyDown="OnKeyDown" IsVisibleChanged="OnIsVisibleChanged">
 
     <DockPanel>
         <controls:NavigationBar DockPanel.Dock="Top" />
@@ -70,7 +70,7 @@
                     </Grid>
                     
                     <!-- Navigation control as a footer, always visible -->
-                    <controls:SrsPageNavigationControl Grid.Row="3" />
+                    <controls:SrsPageNavigationControl x:Name="Navigation" Grid.Row="3" />
                 </Grid>
 
                 <!-- SRS Review control taking the whole space when the review session is started -->

--- a/Kanji.Interface/Views/SrsPage.xaml
+++ b/Kanji.Interface/Views/SrsPage.xaml
@@ -65,7 +65,7 @@
                             <RowDefinition Height="Auto" />
                             <RowDefinition Height="*" />
                         </Grid.RowDefinitions>
-                        <controls:SrsEntryFilterControl DataContext="{Binding FilterVm}" />
+                        <controls:SrsEntryFilterControl x:Name="FilterControl" DataContext="{Binding FilterVm}" />
                         <controls:SrsEntryList Grid.Row="1" DataContext="{Binding ListVm}" />
                     </Grid>
                     

--- a/Kanji.Interface/Views/SrsPage.xaml.cs
+++ b/Kanji.Interface/Views/SrsPage.xaml.cs
@@ -107,25 +107,34 @@ namespace Kanji.Interface.Views
                     break;
                 case Key.M:
                 {
-                    var filterTextBox =
-                        (CommandTextBox)FilterControl.MeaningFilter.Template.FindName("FilterTextBox", FilterControl.MeaningFilter);
-                    filterTextBox.Focus();
-                    e.Handled = true;
+                    if (isCtrlDown)
+                    {
+					    var filterTextBox =
+                            (CommandTextBox)FilterControl.MeaningFilter.Template.FindName("FilterTextBox", FilterControl.MeaningFilter);
+                        filterTextBox.Focus();
+                        e.Handled = true;
+					}
                     break;
                 }
                 case Key.R:
                 {
-                    var filterTextBox =
-                        (CommandTextBox)FilterControl.ReadingFilter.Template.FindName("FilterTextBox", FilterControl.ReadingFilter);
-                    filterTextBox.Focus();
-                    e.Handled = true;
+                    if (isCtrlDown)
+                    {
+                        var filterTextBox =
+                            (CommandTextBox)FilterControl.ReadingFilter.Template.FindName("FilterTextBox", FilterControl.ReadingFilter);
+                        filterTextBox.Focus();
+                        e.Handled = true;
+					}
                     break;
                 }
                 case Key.T:
                 {
-                    var filterTextBox = (CommandTextBox)FilterControl.TagFilter.Template.FindName("FilterTextBox", FilterControl.TagFilter);
-                    filterTextBox.Focus();
-                    e.Handled = true;
+                    if (isCtrlDown)
+                    {
+                        var filterTextBox = (CommandTextBox)FilterControl.TagFilter.Template.FindName("FilterTextBox", FilterControl.TagFilter);
+                        filterTextBox.Focus();
+                        e.Handled = true;
+					}
                     break;
                 }
                 case Key.K:

--- a/Kanji.Interface/Views/SrsPage.xaml.cs
+++ b/Kanji.Interface/Views/SrsPage.xaml.cs
@@ -12,6 +12,7 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Navigation;
 using System.Windows.Shapes;
+using Kanji.Interface.Controls;
 using Kanji.Interface.ViewModels;
 
 namespace Kanji.Interface.Views
@@ -29,22 +30,141 @@ namespace Kanji.Interface.Views
         #endregion
 
         #region Methods
-        
+
         /// <summary>
         /// Since a <see cref="GalaSoft.MvvmLight.Command.RelayCommand"/> does not accept keyboard shortcuts,
         /// we have to manually invoke the commands on a keyboard event.
         /// </summary>
         private void OnKeyDown(object sender, KeyEventArgs e)
         {
+            SrsViewModel viewModel = ((SrsViewModel)DataContext);
+
+            switch (viewModel.ControlMode)
+            {
+                case SrsViewModel.ControlModeEnum.Dashboard:
+                    HandleDashboardInput(e);
+                    break;
+                case SrsViewModel.ControlModeEnum.SimpleFilter:
+                    HandleSimpleFilterInput(e);
+                    break;
+            }
+
+            HandleSharedInput(e);
+        }
+
+        private void HandleDashboardInput(KeyEventArgs e)
+        {
             KeyboardDevice keyboardDevice = e.KeyboardDevice;
 
-            if (keyboardDevice.IsKeyDown(Key.LeftCtrl) || keyboardDevice.IsKeyDown(Key.RightCtrl))
+            SrsViewModel viewModel = ((SrsViewModel)DataContext);
+            bool isCtrlDown = keyboardDevice.IsKeyDown(Key.LeftCtrl) || keyboardDevice.IsKeyDown(Key.RightCtrl);
+
+            switch (e.Key)
             {
-                switch (e.Key)
+                case Key.Enter:
+                    if (isCtrlDown)
+                        viewModel.StartReviewsCommand.Execute(null);
+                    break;
+                case Key.B:
+                    if (isCtrlDown)
+                    {
+                        viewModel.SwitchToSimpleFilterCommand.Execute(null);
+                        e.Handled = true;
+                    }
+                    break;
+            }
+        }
+
+        private void HandleSimpleFilterInput(KeyEventArgs e)
+        {
+            KeyboardDevice keyboardDevice = e.KeyboardDevice;
+
+            SrsViewModel viewModel = ((SrsViewModel)DataContext);
+            bool isCtrlDown = keyboardDevice.IsKeyDown(Key.LeftCtrl) || keyboardDevice.IsKeyDown(Key.RightCtrl);
+            bool isAltDown = keyboardDevice.IsKeyDown(Key.LeftAlt) || keyboardDevice.IsKeyDown(Key.LeftAlt);
+
+            switch (e.Key)
+            {
+                case Key.Home:
+                    // Apparently, the CommandTextBox eats CTRL+Home, so we have to add an Alt.
+                    if (isCtrlDown && isAltDown)
+                    {
+                        viewModel.SwitchToDashboardCommand.Execute(null);
+                        e.Handled = true;
+                    }
+                    break;
+                case Key.F5:
+                    viewModel.FilterVm.RefreshCommand.Execute(null);
+                    e.Handled = true;
+                    break;
+                case Key.A:
+                    // We can't just use CTRL+A here, because that would not work if a text box had focus.
+                    if (isCtrlDown && isAltDown)
+                    {
+                        viewModel.FilterVm.BrowseAllItemsCommand.Execute(null);
+                        e.Handled = true;
+                    }
+                    break;
+                case Key.M:
                 {
-                    case Key.B:
-                        break;
+                    var filterTextBox =
+                        (CommandTextBox)FilterControl.MeaningFilter.Template.FindName("FilterTextBox", FilterControl.MeaningFilter);
+                    filterTextBox.Focus();
+                    e.Handled = true;
+                    break;
                 }
+                case Key.R:
+                {
+                    var filterTextBox =
+                        (CommandTextBox)FilterControl.ReadingFilter.Template.FindName("FilterTextBox", FilterControl.ReadingFilter);
+                    filterTextBox.Focus();
+                    e.Handled = true;
+                    break;
+                }
+                case Key.T:
+                {
+                    var filterTextBox = (CommandTextBox)FilterControl.TagFilter.Template.FindName("FilterTextBox", FilterControl.TagFilter);
+                    filterTextBox.Focus();
+                    e.Handled = true;
+                    break;
+                }
+                case Key.K:
+                    if (isCtrlDown && isAltDown)
+                    {
+                        viewModel.FilterVm.TypeFilterVm.IsKanjiItemEnabled = !viewModel.FilterVm.TypeFilterVm.IsKanjiItemEnabled;
+                    }
+                    break;
+                case Key.V:
+                    if (isCtrlDown && isAltDown)
+                    {
+                        viewModel.FilterVm.TypeFilterVm.IsVocabItemEnabled = !viewModel.FilterVm.TypeFilterVm.IsVocabItemEnabled;
+                    }
+                    break;
+            }
+        }
+
+        private void HandleSharedInput(KeyEventArgs e)
+        {
+            KeyboardDevice keyboardDevice = e.KeyboardDevice;
+
+            SrsViewModel viewModel = ((SrsViewModel)DataContext);
+            bool isCtrlDown = keyboardDevice.IsKeyDown(Key.LeftCtrl) || keyboardDevice.IsKeyDown(Key.RightCtrl);
+            bool isAltDown = keyboardDevice.IsKeyDown(Key.LeftAlt) || keyboardDevice.IsKeyDown(Key.LeftAlt);
+
+            switch (e.Key)
+            {
+                case Key.K:
+                    if (isCtrlDown && !isAltDown)
+                        viewModel.AddKanjiItemCommand.Execute(null);
+                    break;
+                case Key.V:
+                    if (isCtrlDown && !isAltDown)
+                        viewModel.AddVocabItemCommand.Execute(null);
+                    break;
+                case Key.I:
+                    if (isCtrlDown)
+                        viewModel.ImportCommand.Execute(null);
+                    break;
             }
         }
 

--- a/Kanji.Interface/Views/SrsPage.xaml.cs
+++ b/Kanji.Interface/Views/SrsPage.xaml.cs
@@ -18,10 +18,46 @@ namespace Kanji.Interface.Views
 {
     public partial class SrsPage : UserControl
     {
+        #region Constructors
+
         public SrsPage()
         {
             InitializeComponent();
             DataContext = new SrsViewModel();
         }
+
+        #endregion
+
+        #region Methods
+        
+        /// <summary>
+        /// Since a <see cref="GalaSoft.MvvmLight.Command.RelayCommand"/> does not accept keyboard shortcuts,
+        /// we have to manually invoke the commands on a keyboard event.
+        /// </summary>
+        private void OnKeyDown(object sender, KeyEventArgs e)
+        {
+            KeyboardDevice keyboardDevice = e.KeyboardDevice;
+
+            if (keyboardDevice.IsKeyDown(Key.LeftCtrl) || keyboardDevice.IsKeyDown(Key.RightCtrl))
+            {
+                switch (e.Key)
+                {
+                    case Key.B:
+                        break;
+                }
+            }
+        }
+
+        private void OnIsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e)
+        {
+            // Focus the page once it becomes visible.
+            // This is so that the navigation bar does not keep the focus, which would prevent shortcut keys from working.
+            if (((bool)e.NewValue))
+            {
+                Focus();
+            }
+        }
+
+        #endregion
     }
 }

--- a/Kanji.Interface/Views/VocabPage.xaml
+++ b/Kanji.Interface/Views/VocabPage.xaml
@@ -4,8 +4,8 @@
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:controls="clr-namespace:Kanji.Interface.Controls"
-      mc:Ignorable="d" 
-      d:DesignHeight="300" d:DesignWidth="600">
+      mc:Ignorable="d" Focusable="true"
+      d:DesignHeight="300" d:DesignWidth="600" KeyDown="OnKeyDown" IsVisibleChanged="OnIsVisibleChanged">
     
     <DockPanel>
         <controls:NavigationBar DockPanel.Dock="Top" />
@@ -21,7 +21,7 @@
                 </Grid.RowDefinitions>
 
                 <!-- Filter panel -->
-                <controls:VocabFilterControl DataContext="{Binding VocabFilterVm}" />
+                <controls:VocabFilterControl x:Name="FilterControl" DataContext="{Binding VocabFilterVm}" />
 
                 <!-- Results list -->
                 <controls:VocabList DataContext="{Binding VocabListVm}" Grid.Row="1" />

--- a/Kanji.Interface/Views/VocabPage.xaml.cs
+++ b/Kanji.Interface/Views/VocabPage.xaml.cs
@@ -44,20 +44,27 @@ namespace Kanji.Interface.Views
                 {
                     case Key.R:
                         FilterControl.ReadingFilter.Focus();
+                        e.Handled = true;
                         break;
                     case Key.M:
                         FilterControl.MeaningFilter.Focus();
+                        e.Handled = true;
                         break;
                     case Key.W:
                         FilterControl.WkLevelFilter.LevelSlider.Focus();
+                        e.Handled = true;
                         break;
                     case Key.J:
                         FilterControl.JlptLevelFilter.LevelSlider.Focus();
+                        e.Handled = true;
                         break;
                     case Key.C:
                         // We can't just use CTRL+C here, because that would not work if a text box had focus.
                         if (keyboardDevice.IsKeyDown(Key.LeftAlt) || keyboardDevice.IsKeyDown(Key.RightAlt))
+                        {
                             FilterControl.CategoryFilter.ComboBox.Focus();
+                            e.Handled = true;
+                        }
                         break;
                 }
             }

--- a/Kanji.Interface/Views/VocabPage.xaml.cs
+++ b/Kanji.Interface/Views/VocabPage.xaml.cs
@@ -68,6 +68,14 @@ namespace Kanji.Interface.Views
                         break;
                 }
             }
+
+            switch (e.Key)
+            {
+                case Key.Enter:
+                    FilterControl.ApplyFilterButton.Command.Execute(null);
+                    e.Handled = true;
+                    break;
+            }
         }
 
         private void OnIsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e)

--- a/Kanji.Interface/Views/VocabPage.xaml.cs
+++ b/Kanji.Interface/Views/VocabPage.xaml.cs
@@ -18,10 +18,61 @@ namespace Kanji.Interface.Views
 {
     public partial class VocabPage : UserControl
     {
+        #region Constructors
+
         public VocabPage()
         {
             InitializeComponent();
             DataContext = new VocabViewModel();
         }
+
+        #endregion
+
+        #region Methods
+        
+        /// <summary>
+        /// Since a <see cref="GalaSoft.MvvmLight.Command.RelayCommand"/> does not accept keyboard shortcuts,
+        /// we have to manually invoke the commands on a keyboard event.
+        /// </summary>
+        private void OnKeyDown(object sender, KeyEventArgs e)
+        {
+            KeyboardDevice keyboardDevice = e.KeyboardDevice;
+
+            if (keyboardDevice.IsKeyDown(Key.LeftCtrl) || keyboardDevice.IsKeyDown(Key.RightCtrl))
+            {
+                switch (e.Key)
+                {
+                    case Key.R:
+                        FilterControl.ReadingFilter.Focus();
+                        break;
+                    case Key.M:
+                        FilterControl.MeaningFilter.Focus();
+                        break;
+                    case Key.W:
+                        FilterControl.WkLevelFilter.LevelSlider.Focus();
+                        break;
+                    case Key.J:
+                        FilterControl.JlptLevelFilter.LevelSlider.Focus();
+                        break;
+                    case Key.C:
+                        // We can't just use CTRL+C here, because that would not work if a text box had focus.
+                        if (keyboardDevice.IsKeyDown(Key.LeftAlt) || keyboardDevice.IsKeyDown(Key.RightAlt))
+                            FilterControl.CategoryFilter.ComboBox.Focus();
+                        break;
+                }
+            }
+        }
+
+        private void OnIsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e)
+        {
+            // Focus the page once it becomes visible.
+            // This is so that the navigation bar does not keep the focus, which would prevent shortcut keys from working.
+            if (((bool)e.NewValue))
+            {
+                Focus();
+            }
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
In a nutshell, I added:
- Keyboard shortcuts for the Kanji and Vocab tabs, and for switching between them (the SRS tab does not have any shortcuts yet). Also for the SRS windows. Can you look at it and let me know if the way I did it (especially how I indicated the shortcuts in tooltips) is okay with you?
- The Wrap Up feature in reviews. It looks a little awkward because we need a new button, which really shouldn't be hidden while you haven't submitted an answer yet like the other buttons. And it would look even weirder to put that button on a separate row, all on its own. Maybe I could put it at the top, near the 'Close Review' button. Actually, come to think of it, the 'Close Review' button can really just be replaced with the 'Wrap Up' button, can't it?
