### PR TITLE
Made readings and meanings optional

### DIFF
--- a/Kanji.Interface/ViewModels/Partial/Import/CSV/CsvImportColumnsStepViewModel.cs
+++ b/Kanji.Interface/ViewModels/Partial/Import/CSV/CsvImportColumnsStepViewModel.cs
@@ -337,19 +337,9 @@ namespace Kanji.Interface.ViewModels
 
                 // Find readings.
                 entry.Readings = ReadAcceptedReadings(row);
-                if (string.IsNullOrEmpty(entry.Readings))
-                {
-                    log.Append("Empty readings. Skipping.");
-                    return null;
-                }
 
                 // Find meanings.
                 entry.Meanings = ReadAcceptedMeanings(row);
-                if (string.IsNullOrEmpty(entry.Meanings))
-                {
-                    log.Append("Empty meanings. Skipping.");
-                    return null;
-                }
 
                 // Find all optional info.
                 entry.MeaningNote = ReadMeaningNotes(row);


### PR DESCRIPTION
Houhou 1.2 made the meaning and reading field optional in Houhou, however the CSV import still requires them.