### PR TITLE
Prevent SRS being created multiple times for a kanji

### DIFF
--- a/Kanji.Interface/ViewModels/Partial/Kanji/KanjiListViewModel.cs
+++ b/Kanji.Interface/ViewModels/Partial/Kanji/KanjiListViewModel.cs
@@ -168,6 +168,7 @@ namespace Kanji.Interface.ViewModels
         {
             if (KanjiSelected != null && kanji != null)
             {
+                ReapplyFilter();
                 KanjiSelected(this, new KanjiSelectedEventArgs(kanji));
             }
         }


### PR DESCRIPTION
Fixes #5 

I was able to pinpoint how #5 happens. Steps to reproduce:
1. Search for any 2+ Kanji compound in vocab tab
2. Click on one of the kanji
3. Add this kanji to SRS
4. From kanji list on the right, click the other kanji then the original kanji again - Add button is there as if kanji was not already added, which lets user add it to their SRS again

Was able to fix this by reapplying the filter when a kanji is selected from the list.

I rebase this branch onto your master so you can choose to merge it before  #24  since this is a more simple change. Whichever one you merge last might require a rebase